### PR TITLE
[fix]docker_compose.ymlを修正しmysql_dataをローカル上に保持

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     # DBのレコードが日本語だと文字化けするので、utf8をセットする
     command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
     volumes:
-      - ./db/mysql/volumes:/var/lib/mysql
+      - mysql_data:/var/lib/mysql
     # 環境変数
     environment:
       MYSQL_ROOT_PASSWORD: password
@@ -35,3 +35,4 @@ services:
 # コンテナを作り直したとしてもPC上に残るようにするために設定
 volumes:
   gem_data:
+  mysql_data:


### PR DESCRIPTION
対応するissue
---
close #11

概要
---

- volumeをローカルに保持するように修正
- mysql/volumesディレクトリを削除


エンドポイント
---




UI の比較
----




実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- 追加した gem があれば url を添えて書いてください

備考
---

その他になにかあれば