### PR TITLE
[認証機能]sign-inを作成

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -26,7 +26,7 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   def after_sign_in_path_for(_resource)
-    dashbord_path
+    dashboard_path
   end
 
   def after_sign_out_path_for(_resource)

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -15,16 +15,16 @@
             <%= link_to '過去問演習', '#' %>
         </div>
         <!-- パスができたら修正 -->
-        <% if false %>
+        <% if user_signed_in? %>
             <div class="mr-5 hover:text-orange-300">
-                <%= button_to 'ログアウト', '#', method: :delete, data: { turbo_method: :delete } %>
+                <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete } %>
             </div>
             <div class="mr-5 hover:text-orange-300">
                 <%= link_to 'マイページ', '#' %>
             </div>
         <% else %>
             <div class="mr-5 hover:text-orange-300">
-                <%= link_to 'ログイン', '#' %>
+                <%= link_to 'ログイン', new_user_session_path %>
             </div>
         <% end %>
     </nav>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,40 @@
-<h2><%= t('.sign_in') %></h2>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email' %>
-  </div>
+  <%= form_with(model: resource, as: resource_name, url: user_session_path(resource_name),
+                method: :post, local: true, html: { class: 'mt-8 space-y-6 sm:mx-auto sm:w-full sm:max-w-md' }) do |f| %>
+    <%= render 'devise/shared/error_messages', resource: %>
 
-  <div class="field">
-    <%= f.label :password %><br>
-    <%= f.password_field :password, autocomplete: 'current-password' %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+    <div class="space-y-4">
+      <div>
+        <%= f.email_field :email, autofocus: true, autocomplete: 'email',
+                                  placeholder: t('devise.registrations.new.email'),
+                                  class: 'appearance-none rounded-md relative block w-full px-3 py-2 border
+                                          border-gray-300 text-gray-900 placeholder-gray-500
+                                          focus:outline-none focus:ring-sky-500 focus:border-sky-500
+                                          sm:text-sm sm:leading-5' %>
+      </div>
+      <div>
+        <%= f.password_field :password, autocomplete: 'current-password',
+                                        placeholder: t('devise.registrations.new.password'),
+                                        class: 'appearance-none rounded-md relative block w-full px-3 py-2
+                                                border border-gray-300 text-gray-900 placeholder-gray-500
+                                                focus:outline-none focus:ring-sky-500 focus:border-sky-500
+                                                sm:text-sm sm:leading-5' %>
+      </div>
+      <% if devise_mapping.rememberable? %>
+        <div class="field">
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me %>
+        </div>
+      <% end %>
+      <div class="actions bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300 font-bold py-2 px-4 rounded-lg shadow-xl text-center">
+        <%= f.submit 'ログイン' %>
+      </div>
     </div>
   <% end %>
-
-  <div class="actions">
-    <%= f.submit t('.sign_in') %>
+  <div class="m-5">
+    <p class="text-center text-gray-900">
+      パスワードを忘れた場合は<%= link_to 'こちら', new_password_path(resource_name), class: 'text-sky-500 hover:text-orange-300' %>
+    </p>
   </div>
-<% end %>
-
-<%= render 'users/shared/links' %>
+</div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
 
-  <%= form_with(model: resource, as: resource_name, url: user_session_path(resource_name),
+  <%= form_with(model: resource, as: resource_name, url: user_session_path,
                 method: :post, local: true, html: { class: 'mt-8 space-y-6 sm:mx-auto sm:w-full sm:max-w-md' }) do |f| %>
     <%= render 'devise/shared/error_messages', resource: %>
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "Users", type: :request do
         expect {
           post user_registration_path, params: user_params
         }.to change(User, :count).by(1)
-        expect(response).to redirect_to(dashboard_path) 
+        expect(response).to redirect_to(dashboard_path)
+        expect(response).to have_http_status(:see_other)#Rails7では、POSTリクエスト後のリダイレクトは303
       end
     end
 
@@ -26,6 +27,29 @@ RSpec.describe "Users", type: :request do
           post user_registration_path, params: user_params
         }.not_to change(User, :count)
         expect(response).to render_template(:new)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe "POST /users/sign_in" do
+    context '正常系' do
+      it 'ログイン後ダッシュボード画面にリダイレクトされる' do
+        user = User.create(username: 'testuser', email: 'testuser@example.com', password: 'password', password_confirmation: 'password')
+        user_params = { user: { email: 'testuser@example.com', password: 'password' } }
+        post user_session_path, params: user_params
+        expect(response).to redirect_to(dashboard_path)
+        expect(response).to have_http_status(:see_other)
+      end
+    end
+
+    context '不正なパラメータの場合' do
+      it 'ログインができずログイン画面にリダイレクトされる' do
+        user = User.create(username: 'testuser', email: 'testuser@example.com', password: 'password', password_confirmation: 'password')
+        user_params = { user: { email: 'testuser@example.com', password: '123456789' } }
+        post user_session_path, params: user_params
+        expect(response).to render_template(:new)
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -9,22 +9,23 @@ RSpec.describe "Users", type: :request do
   end
 
   describe "POST /users/sign_up" do
+    let(:valid_user_params) { { user: { username: 'newuser', email: 'newuser@example.com', password: 'password', password_confirmation: 'password' } } }
+    let(:invalid_user_params) { { user: { username: '', email: 'user@example.com', password: 'password', password_confirmation: 'password' } } }
+
     context '正常系' do
       it 'ユーザー登録後ダッシュボード画面にリダイレクトされる' do
-        user_params = { user: { username: 'newuser', email: 'newuser@example.com', password: 'password', password_confirmation: 'password' } }
         expect {
-          post user_registration_path, params: user_params
+          post user_registration_path, params: valid_user_params
         }.to change(User, :count).by(1)
         expect(response).to redirect_to(dashboard_path)
-        expect(response).to have_http_status(:see_other)#Rails7では、POSTリクエスト後のリダイレクトは303
+        expect(response).to have_http_status(:see_other)
       end
     end
 
     context '不正なパラメータの場合' do
       it 'ユーザー登録ができず新規登録画面にリダイレクトされる' do
-        user_params = { user: { username: '', email: 'user@example.com', password: 'password', password_confirmation: 'password' } }
         expect {
-          post user_registration_path, params: user_params
+          post user_registration_path, params: invalid_user_params
         }.not_to change(User, :count)
         expect(response).to render_template(:new)
         expect(response).to have_http_status(:unprocessable_entity)
@@ -33,11 +34,14 @@ RSpec.describe "Users", type: :request do
   end
 
   describe "POST /users/sign_in" do
+    let(:user) { User.create(username: 'testuser', email: 'testuser@example.com', password: 'password', password_confirmation: 'password') }
+    let(:valid_login_params) { { user: { email: 'testuser@example.com', password: 'password' } } }
+    let(:invalid_login_params) { { user: { email: 'testuser@example.com', password: '123456789' } } }
+
     context '正常系' do
       it 'ログイン後ダッシュボード画面にリダイレクトされる' do
-        user = User.create(username: 'testuser', email: 'testuser@example.com', password: 'password', password_confirmation: 'password')
-        user_params = { user: { email: 'testuser@example.com', password: 'password' } }
-        post user_session_path, params: user_params
+        user
+        post user_session_path, params: valid_login_params
         expect(response).to redirect_to(dashboard_path)
         expect(response).to have_http_status(:see_other)
       end
@@ -45,9 +49,7 @@ RSpec.describe "Users", type: :request do
 
     context '不正なパラメータの場合' do
       it 'ログインができずログイン画面にリダイレクトされる' do
-        user = User.create(username: 'testuser', email: 'testuser@example.com', password: 'password', password_confirmation: 'password')
-        user_params = { user: { email: 'testuser@example.com', password: '123456789' } }
-        post user_session_path, params: user_params
+        post user_session_path, params: invalid_login_params
         expect(response).to render_template(:new)
         expect(response).to have_http_status(:unprocessable_entity)
       end


### PR DESCRIPTION
対応するissue
---
close #i4

概要
---

deviseを用いいてログイン機能を作成しました。
併せてログイン機能のリクエストスペックも作成しました。

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `GET /users/sign_in`| `users/sessions#inew` | ログイン画面を表示する |
| `POST /users/sign_in`| `users/sessions#icreate` | ログインする |


UI の比較
----

| 現状 | figma | 
|:------:|:------:|
| <a href="https://gyazo.com/4939606c6324471965e16eb2032e8de1"><img src="https://i.gyazo.com/4939606c6324471965e16eb2032e8de1.png" alt="Image from Gyazo" width="400"/></a>| <a href="https://gyazo.com/dab09b16b88c08d7a061b83fa20eaf69"><img src="https://i.gyazo.com/dab09b16b88c08d7a061b83fa20eaf69.png" alt="Image from Gyazo" width="400"/></a> | 



実装の詳細
----

- ログイン後はヘッダーにログアウト用のボタンが表示されるように修正しています。
- omni_authでのログインは実装していません。
- 一部sign_upに関するテストも修正しました。

追加した Gem
---

- ありません

備考
---

その他になにかあれば