### PR TITLE
[認証機能]パスワード変更機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,9 +60,9 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'launchy'
+  gem 'letter_opener_web'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
-  gem 'letter_opener_web'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test do
   gem 'launchy'
   gem 'rails-controller-testing'
   gem 'rspec-rails'
+  gem 'letter_opener_web'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
-    builder (3.2.4)
+    builder (3.3.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -98,7 +98,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (5.0.0)
-    concurrent-ruby (1.2.3)
+    concurrent-ruby (1.3.3)
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -120,7 +120,7 @@ GEM
       rainbow
       rubocop
       smart_properties
-    erubi (1.12.0)
+    erubi (1.13.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -130,7 +130,7 @@ GEM
       i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.0.1)
       actionpack (>= 6.0.0)
@@ -160,7 +160,7 @@ GEM
     matrix (0.4.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.22.3)
+    minitest (5.24.0)
     msgpack (1.7.2)
     mysql2 (0.5.6)
     net-imap (0.4.10)
@@ -173,9 +173,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
-    nokogiri (1.16.4-aarch64-linux)
+    nokogiri (1.16.6-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.4-arm64-darwin)
+    nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.24.0)
@@ -187,7 +187,7 @@ GEM
     public_suffix (5.0.5)
     puma (5.6.8)
       nio4r (~> 2.0)
-    racc (1.7.3)
+    racc (1.8.0)
     rack (2.2.9)
     rack-test (2.1.0)
       rack (>= 1.3)
@@ -301,10 +301,10 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
-    tailwindcss-rails (2.4.1-aarch64-linux)
-      railties (>= 6.0.0)
-    tailwindcss-rails (2.4.1-arm64-darwin)
-      railties (>= 6.0.0)
+    tailwindcss-rails (2.6.1-aarch64-linux)
+      railties (>= 7.0.0)
+    tailwindcss-rails (2.6.1-arm64-darwin)
+      railties (>= 7.0.0)
     thor (1.3.1)
     timeout (0.4.1)
     turbo-rails (2.0.5)
@@ -331,7 +331,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   aarch64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,13 @@ GEM
     launchy (3.0.0)
       addressable (~> 2.8)
       childprocess (~> 5.0)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -351,6 +358,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   launchy
+  letter_opener_web
   mysql2 (~> 0.5)
   puma (~> 5.0)
   rails (~> 7.0.8, >= 7.0.8.1)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,2 @@
-web: bin/rails server
-css: bin/rails tailwindcss:watch
+web: bin/rails server -b 0.0.0.0
+css: bin/rails tailwindcss:watch[poll]

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -23,7 +23,7 @@ class Users::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  def after_resetting_password_path_for(resource)
+  def after_resetting_password_path_for(_resource)
     dashboard_path
   end
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -23,9 +23,9 @@ class Users::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+  def after_resetting_password_path_for(resource)
+    dashboard_path
+  end
 
   # The path used after sending reset password instructions
   # def after_sending_reset_password_instructions_path_for(resource_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string(255)
+#  confirmed_at           :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string(255)
+#  unconfirmed_email      :string(255)
+#  username               :string(255)      not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_username              (username) UNIQUE
+#
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/users/mailer/reset_password_instructions.html.erb
+++ b/app/views/users/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
 <p><%= t('.greeting', recipient: @resource.email) %></p>
 
-<p><%= t('.instruction') %></p>
+<p>国試ex_PTのパスワード再設定を受付ました。</p>
+<p>下記リンクよりパスワードを再設定してください。</p>
+<p><%= link_to 'パスワードの再設定', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p><%= link_to t('.action'), edit_password_url(@resource, reset_password_token: @token) %></p>
-
-<p><%= t('.instruction_2') %></p>
-<p><%= t('.instruction_3') %></p>
+<p>お心当たりのない場合はこのメールを無視してください</p>
+<p>※本メールの受信時点ではパスワードの再設定は完了していません</p>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -1,25 +1,34 @@
-<h2><%= t('.change_your_password') %></h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-center text-3xl font-bold text-gray-900">パスワードの変更</h2>
+  </div>
+  <%= form_with(model: resource, as: resource_name, url: password_path(resource_name),
+                method: :put, local: true, html: { class: 'mt-8 space-y-6 sm:mx-auto sm:w-full sm:max-w-md' }) do |f| %>
   <%= render 'users/shared/error_messages', resource: %>
   <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, t('.new_password') %><br>
-    <% if @minimum_password_length %>
-      <em><%= t('devise.shared.minimum_password_length', count: @minimum_password_length) %></em><br>
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: 'new-password' %>
-  </div>
+  <div class="space-y-4">
+      <div>
+        <i class="text-sm text-gray-900"><%= t('devise.registrations.new.minimum_password_length') %></i>
+        <%= f.password_field :password, autocomplete: 'new-password',
+                                        placeholder: '新しいパスワード',
+                                        class: 'appearance-none rounded-md relative block w-full px-3 py-2
+                                                border border-gray-300 text-gray-900 placeholder-gray-500
+                                                focus:outline-none focus:ring-sky-500 focus:border-sky-500
+                                                sm:text-sm sm:leading-5' %>
+      </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, t('.confirm_new_password') %><br>
-    <%= f.password_field :password_confirmation, autocomplete: 'new-password' %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit t('.change_my_password') %>
-  </div>
-<% end %>
-
-<%= render 'users/shared/links' %>
+      <div>
+        <%= f.password_field :password_confirmation, autocomplete: 'new-password',
+                                                     placeholder: '新しいパスワードの確認',
+                                                     class: 'appearance-none rounded-md relative block w-full px-3 py-2
+                                                             border border-gray-300 text-gray-900 placeholder-gray-500
+                                                             focus:outline-none focus:ring-sky-500 focus:border-sky-500
+                                                             sm:text-sm sm:leading-5' %>
+      </div>
+      <div class="actions bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300 font-bold py-2 px-4 rounded-lg shadow-xl text-center">
+        <%= f.submit 'パスワードを変更する' %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -10,7 +10,7 @@
     <div>
       <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true, autocomplete: 'email',
-                                  placeholder: '再設定用リンクの送信先を入力してください',
+                                  placeholder: 'ご登録のメールアドレスを入力してください',
                                   class: 'appearance-none rounded-md relative block w-full px-3 py-2 border
                                           border-gray-300 text-gray-900 placeholder-gray-500
                                           focus:outline-none focus:ring-sky-500 focus:border-sky-500

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -20,4 +20,10 @@
         <%= f.submit '再設定用リンクを送信' %>
     </div>
   <% end %>
+  <div class="m-5">
+    <p class="text-center text-gray-900">
+      すでにアカウントをお持ちですか？<%= link_to 'ログイン', new_user_session_path, class: 'text-sky-500 hover:text-orange-300' %>
+    </p>
+  </div>
+  <%= render 'users/shared/links' %>
 </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -10,8 +10,8 @@
     <div>
       <%= f.label :email %><br>
       <%= f.email_field :email, autofocus: true, autocomplete: 'email',
-                                  placeholder: 'ご登録のメールアドレスを入力してください',
-                                  class: 'appearance-none rounded-md relative block w-full px-3 py-2 border
+                                placeholder: 'ご登録のメールアドレスを入力してください',
+                                class: 'appearance-none rounded-md relative block w-full px-3 py-2 border
                                           border-gray-300 text-gray-900 placeholder-gray-500
                                           focus:outline-none focus:ring-sky-500 focus:border-sky-500
                                           sm:text-sm sm:leading-5' %>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -22,8 +22,7 @@
   <% end %>
   <div class="m-5">
     <p class="text-center text-gray-900">
-      すでにアカウントをお持ちですか？<%= link_to 'ログイン', new_user_session_path, class: 'text-sky-500 hover:text-orange-300' %>
+      <%= link_to 'ログイン', new_user_session_path, class: 'text-sky-500 hover:text-orange-300' %>
     </p>
   </div>
-  <%= render 'users/shared/links' %>
 </div>

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -1,16 +1,23 @@
-<h2><%= t('.forgot_your_password') %></h2>
-
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render 'users/shared/error_messages', resource: %>
-
-  <div class="field">
-    <%= f.label :email %><br>
-    <%= f.email_field :email, autofocus: true, autocomplete: 'email' %>
+<div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
+  <div class="sm:mx-auto sm:w-full sm:max-w-md">
+    <h2 class="mt-6 text-center text-3xl font-bold text-gray-900"><%= t('devise.passwords.new.title') %></h2>
   </div>
 
-  <div class="actions">
-    <%= f.submit t('.send_me_reset_password_instructions') %>
-  </div>
-<% end %>
+  <%= form_with(model: resource, as: resource_name, url: password_path(resource_name),
+                method: :post, local: true, html: { class: 'mt-8 space-y-6 sm:mx-auto sm:w-full sm:max-w-md' }) do |f| %>
+    <%= render 'devise/shared/error_messages', resource: %>
 
-<%= render 'users/shared/links' %>
+    <div>
+      <%= f.label :email %><br>
+      <%= f.email_field :email, autofocus: true, autocomplete: 'email',
+                                  placeholder: '再設定用リンクの送信先を入力してください',
+                                  class: 'appearance-none rounded-md relative block w-full px-3 py-2 border
+                                          border-gray-300 text-gray-900 placeholder-gray-500
+                                          focus:outline-none focus:ring-sky-500 focus:border-sky-500
+                                          sm:text-sm sm:leading-5' %>
+    </div>
+    <div class="actions bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300 font-bold py-2 px-4 rounded-lg shadow-xl text-center">
+        <%= f.submit '再設定用リンクを送信' %>
+    </div>
+  <% end %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -60,6 +60,7 @@ Rails.application.configure do
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+  config.assets.debug = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,17 +36,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
+  # Letter Opener
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-
   config.action_mailer.delivery_method = :letter_opener_web
-  # メール配信を行うように設定
-  config.action_mailer.perform_deliveries = true
-
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,6 +43,11 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
+  config.action_mailer.delivery_method = :letter_opener_web
+  # メール配信を行うように設定
+  config.action_mailer.perform_deliveries = true
+
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'no-reply@kokushiex.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -82,8 +82,8 @@ ja:
         confirm_new_password: 確認用新しいパスワード
         new_password: 新しいパスワード
       new:
-        forgot_your_password: パスワードを忘れましたか？
-        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+        title: パスワードの再設定
+        send_me_reset_password_instructions: パスワードの再設定用リンクを送信
       no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
       send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
       send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -79,7 +79,7 @@ ja:
       edit:
         change_my_password: パスワードを変更する
         change_your_password: パスワードを変更
-        confirm_new_password: 確認用新しいパスワード
+        confirm_new_password: 新しいパスワードの確認
         new_password: 新しいパスワード
       new:
         title: パスワードの再設定

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -60,11 +60,11 @@ ja:
         message: パスワードが再設定されました。
         subject: パスワードの変更について
       reset_password_instructions:
-        action: パスワード変更
-        greeting: "%{recipient}様"
-        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
-        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
-        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        action: パスワードの再設定
+        greeting: "%{recipient} 様"
+        instruction: 国試ex_PTのパスワード再設定を受付ました。下記リンクよりパスワードを再設定してください。
+        instruction_2: お心当たりのない場合はこのメールを無視してください
+        instruction_3: ※本メールの受信時点ではパスワードの再設定は完了していません
         subject: パスワードの再設定について
       unlock_instructions:
         action: アカウントのロック解除

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,6 +41,3 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
-
-# https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#live-rebuild
-plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,3 +41,6 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
+
+# https://github.com/rails/tailwindcss-rails?tab=readme-ov-file#live-rebuild
+plugin :tailwindcss if ENV.fetch("RAILS_ENV", "development") == "development"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,5 +8,7 @@ Rails.application.routes.draw do
   root to: 'top#index'
   get '/dashboard' => 'dashboard#index'
 
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,6 @@ Rails.application.routes.draw do
   
   root to: 'top#index'
   get '/dashboard' => 'dashboard#index'
+
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations',
-    sessions: 'users/sessions'
+    sessions: 'users/sessions',
+    passwords: 'users/passwords'
   }
   
   root to: 'top#index'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # build: .でdocker-compose.ymlと同じフォルダにDockerfileがあることを示す
     build: .
     # 毎回 rm tmp/pids/server.pid するのも手間であるため事前に手元で/tmp/pids/server.pidを削除する
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0' & bin/rails tailwindcss:watch"
+    command: bash -c "rm -f tmp/pids/server.pid && bin/dev"
     volumes:
       - .:/app
       - gem_data:/usr/local/bundle

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'true',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'false',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'false',
+      'exclude_serializers'         => 'false',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string(255)
+#  confirmed_at           :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string(255)
+#  unconfirmed_email      :string(255)
+#  username               :string(255)      not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_username              (username) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     username { Faker::Name.unique.name }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,28 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string(255)
+#  confirmed_at           :datetime
+#  email                  :string(255)      default(""), not null
+#  encrypted_password     :string(255)      default(""), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string(255)
+#  unconfirmed_email      :string(255)
+#  username               :string(255)      not null
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_username              (username) UNIQUE
+#
 require 'rails_helper'
 
 RSpec.describe User, type: :model do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,10 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::Test::IntegrationHelpers, type: :request
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures')
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ require_relative '../config/environment'
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rspec'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -34,6 +35,11 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :request
+
+  # テスト環境全体でのホスト情報設定
+  config.before(:each) do
+    ActionMailer::Base.default_url_options[:host] = 'localhost:3000'
+  end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures')
 

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'Users::passwords' do
+  let(:user) {create(:user)}
+
+  describe 'GET /users/password/new' do
+    it 'パスワードリセットリクエスト送信先入力用のformが表示される' do
+      get '/users/password/new'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'POST /users/password' do
+    let(:params) { { user: { email: user.email } } }
+
+    it 'パスワードリセットメールが送信後リダイレクトされる' do
+      expect do
+        post('/users/password', params:)
+        expect(response).to redirect_to('/users/sign_in')
+      end.to change { user.reload.reset_password_sent_at }.from(nil)
+    end
+  end
+
+  describe 'GET /users/password/edit' do
+    let(:reset_password_token) { Devise.token_generator.digest(User, :reset_password_token, 'abcdef') }
+
+    it 'パスワード変更画面が表示される' do
+      get '/users/password/edit?reset_password_token=abcdef'
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'PUT /users/password' do
+    let(:reset_password_token) { user.send_reset_password_instructions }
+    let(:params) do
+      {
+        user: {
+          reset_password_token:,
+          password: 'new-password',
+          password_confirmation: 'new-password',
+        },
+      }
+    end
+
+    it 'パスワードが更新される' do
+      put('/users/password', params:)
+      user.reload
+      expect(user.valid_password?('newpassword')).to be true
+      expect(user.reset_password_token).to be_nil
+    end
+  end
+end

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Users::passwords' do
   end
 
   describe 'PUT /users/password' do
-    let(:reset_password_token) { user.send_reset_password_instructions }
+    let(:reset_password_token) { user.send(:set_reset_password_token) }
     let(:params) do
       {
         user: {
@@ -45,7 +45,7 @@ RSpec.describe 'Users::passwords' do
     it 'パスワードが更新される' do
       put('/users/password', params:)
       user.reload
-      expect(user.valid_password?('newpassword')).to be true
+      expect(user.valid_password?('new-password')).to be true
       expect(user.reset_password_token).to be_nil
     end
   end


### PR DESCRIPTION
対応するissue
---
close #5

概要
---

passwordの再設定機能を実装しました。これに際し、メールの通知確認のために`leter_opener_web`を使用しました。
また当初cssがbuildされないエラーが発生しましたのでdockerfleなども修正しました


エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `GET /password/new`| `users/passwords#new` | パスワード変更申請formを表示する |
| `GET /password/edit`| `users/passwords#edit` | パスワード変更画面を表示する |
| `PUT /password/edit`| `users/passwords#update` | パスワード変更する |

UI の比較
----

| 変更申請form | パスワード変更画面 | 
|:------:|:------:|
| <a href="https://gyazo.com/23388e547398ae3dad14bec40d7b271f"><img src="https://i.gyazo.com/23388e547398ae3dad14bec40d7b271f.png" alt="Image from Gyazo" width="771"/></a> | <a href="https://gyazo.com/c1b90fd3f7a5eda656f63ad6e1b31703"><img src="https://i.gyazo.com/c1b90fd3f7a5eda656f63ad6e1b31703.png" alt="Image from Gyazo" width="770"/></a> | 



実装の詳細
----

- deviseの通常からリダイレクト先のみ変更
- anotate有効化した差分も含まれている

追加した Gem
---

- `gem letter_opener_web`

備考
---

その他になにかあれば