### PR TITLE
 redisとsidekiqの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'seed-fu'
 # decorator
 gem 'draper'
 
+# BackGround Job
+gem 'sidekiq'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem 'draper'
 # BackGround Job
 gem 'sidekiq'
 
+# Configuration
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,10 @@ GEM
     devise-i18n (1.12.0)
       devise (>= 4.9.0)
     diff-lcs (1.5.1)
+    dotenv (3.1.4)
+    dotenv-rails (3.1.4)
+      dotenv (= 3.1.4)
+      railties (>= 6.1)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -383,6 +387,7 @@ DEPENDENCIES
   debug
   devise
   devise-i18n
+  dotenv-rails
   draper
   erb_lint
   factory_bot_rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       xpath (~> 3.2)
     childprocess (5.0.0)
     concurrent-ruby (1.3.3)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.4)
     debug (1.9.2)
@@ -169,6 +170,7 @@ GEM
       letter_opener (~> 1.9)
       railties (>= 6.1)
       rexml
+    logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -248,6 +250,8 @@ GEM
     rake (13.2.1)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
+    redis-client (0.22.2)
+      connection_pool
     regexp_parser (2.9.0)
     reline (0.5.3)
       io-console (~> 0.5)
@@ -317,6 +321,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.3.2)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -392,6 +402,7 @@ DEPENDENCIES
   rubocop-rspec
   seed-fu
   selenium-webdriver
+  sidekiq
   sprockets-rails
   stimulus-rails
   tailwindcss-rails

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,6 @@ module App
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: 'redis://redis:6379' }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: 'redis://redis:6379' }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,12 @@ Rails.application.routes.draw do
   get '/tests/:id' => 'tests#show', as: 'test'
   
   resources :user_responses, only: [:create]
+# 必要かわからないが一応追加
+# 参考：https://qiita.com/lemonade_37/items/296bc211cf3e781c5600#:~:text=%E3%83%80%E3%83%83%E3%82%B7%E3%83%A5%E3%83%9C%E3%83%BC%E3%83%89%E3%81%AB%E3%81%AF%E4%B8%80%E8%88%AC%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%81%AF%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84%E3%82%88%E3%81%86%E3%81%ABBasic%E8%AA%8D%E8%A8%BC%E3%82%92%E3%81%A4%E3%81%91%E3%82%8B%E3%81%AE%E3%81%8C%E6%9C%9B%E3%81%BE%E3%81%97%E3%81%84%E3%81%A7%E3%81%99
+  Sidekiq::Web.use(Rack::Auth::Basic) do |user_id, password|
+    [user_id, password] == [ENV['SIDEKIQ_BASIC_ID'], ENV['SIDEKIQ_BASIC_PASSWORD']]
+  end
+  mount Sidekiq::Web, at: '/sidekiq'
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  require 'sidekiq/web'
     devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions',
@@ -19,9 +20,6 @@ Rails.application.routes.draw do
   resources :user_responses, only: [:create]
 # 必要かわからないが一応追加
 # 参考：https://qiita.com/lemonade_37/items/296bc211cf3e781c5600#:~:text=%E3%83%80%E3%83%83%E3%82%B7%E3%83%A5%E3%83%9C%E3%83%BC%E3%83%89%E3%81%AB%E3%81%AF%E4%B8%80%E8%88%AC%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%81%AF%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84%E3%82%88%E3%81%86%E3%81%ABBasic%E8%AA%8D%E8%A8%BC%E3%82%92%E3%81%A4%E3%81%91%E3%82%8B%E3%81%AE%E3%81%8C%E6%9C%9B%E3%81%BE%E3%81%97%E3%81%84%E3%81%A7%E3%81%99
-  Sidekiq::Web.use(Rack::Auth::Basic) do |user_id, password|
-    [user_id, password] == [ENV['SIDEKIQ_BASIC_ID'], ENV['SIDEKIQ_BASIC_PASSWORD']]
-  end
   mount Sidekiq::Web, at: '/sidekiq'
 
   if Rails.env.development?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ services:
 
   sidekiq:
     build: .
+    environment:
+      REDIS_URL: "redis://redis:6379"
     command: bundle exec sidekiq
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     tty: true
     # stdin_openとは標準入出力とエラー出力をコンテナに結びつける設定
     stdin_open: true
+
   db:
     image: mysql:8.3
     # m1はplatformを指定して、linux/amd64にエミュレートする指定をすることで正常に動く
@@ -31,8 +32,28 @@ services:
       TZ: "Asia/Tokyo"
     ports:
       - "3306:3306"
+
+  redis:
+    image: "redis:latest"
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
+  sidekiq:
+    build: .
+    command: bundle exec sidekiq
+    volumes:
+      - .:/app
+      - gem_data:/usr/local/bundle
+    depends_on:
+      - redis
+      - db
+    tty: true
+    stdin_open: true
 # PC上にdb-volumeという名前でデータ領域が作成される
 # コンテナを作り直したとしてもPC上に残るようにするために設定
 volumes:
   gem_data:
   mysql_data:
+  redis_data:


### PR DESCRIPTION
対応するissue
---
close #36

概要
---

docker-compose.ymlにredisとsidekiqを追加してコンテナを作成しました。sidekiqはgemを使用しています
sidekiqのダッシュボード一応追加しました

実装の詳細
----

- https://qiita.com/lemonade_37/items/296bc211cf3e781c5600#:~:text=%E3%83%80%E3%83%83%E3%82%B7%E3%83%A5%E3%83%9C%E3%83%BC%E3%83%89%E3%81%AB%E3%81%AF%E4%B8%80%E8%88%AC%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%81%AF%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84%E3%82%88%E3%81%86%E3%81%ABBasic%E8%AA%8D%E8%A8%BC%E3%82%92%E3%81%A4%E3%81%91%E3%82%8B%E3%81%AE%E3%81%8C%E6%9C%9B%E3%81%BE%E3%81%97%E3%81%84%E3%81%A7%E3%81%99%E3%80%82
- 上記を参考にsidekiqのダッシュボードにはbasic認証を設定した方がいいようだが、.envの設定が悪いのかうまくいかないため、今回は設定しなかった

追加した Gem
---

- gem 'sidekiq'
- gem 'dotenv-rails

備考
---

その他になにかあれば