### PR TITLE
dashboardの前回のレポートを作成する

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,3 +1,8 @@
 class DashboardController < ApplicationController
-  def index; end
+  def index
+    # current_userの最新のexamaminationを取得
+    @latest_examination = current_user.examinations.order(created_at: :desc).first
+    
+    # ... 他のコード ...
+  end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -2,7 +2,7 @@ class DashboardController < ApplicationController
   def index
     # current_userの最新のexamaminationを取得
     @latest_examination = current_user.examinations.order(created_at: :desc).first
-    
-    # ... 他のコード ...
+    # latest_examinationのscoreを取得
+    @latest_score = @latest_examination.score if @latest_examination
   end
 end

--- a/app/decorators/test_decorator.rb
+++ b/app/decorators/test_decorator.rb
@@ -2,8 +2,15 @@ class TestDecorator < Draper::Decorator
   delegate_all
 
   def question_code(question)
-    implementation_year = object.year.to_i - 1965
     abbreviated_session = question.test_session.session == 'AM' ? 'A' : 'P'
-    "#{implementation_year}#{abbreviated_session}#{question.question_number}"
+    "#{turn}#{abbreviated_session}#{question.question_number}"
+  end
+
+  def turn
+    object.year.to_i - 1965
+  end
+
+  def implementation_year
+    "第#{turn}回(#{object.year}年度)"
   end
 end

--- a/app/models/test.rb
+++ b/app/models/test.rb
@@ -9,7 +9,7 @@
 #
 class Test < ApplicationRecord
   has_many :test_sessions, dependent: :destroy
-  has_many :pass_marks, dependent: :destroy
+  has_one :pass_mark, dependent: :destroy
   has_many :examinations, through: :test_sessions, dependent: :destroy
 
   validates :year, presence: true

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -15,7 +15,7 @@
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>専門</h3>
-# TODO: scoreテーブルにspecial_scoreのカラムを作成する %>
+                            <%# TODO: scoreテーブルにspecial_scoreのカラムを作成する %>
                             <div class='text-3xl text-sky-500'>専門</div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -5,24 +5,26 @@
             <div class='w-full h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden shadow-xl'>
                 <div class='m-5'>
                     <h2 class='font-bold text-xl'>前回のレポート</h2>
-                    <div class='text-center my-2 text-4xl text-sky-500'><%= @latest_examination.test.decorate.implementation_year %></div>
+                    <div class='text-center my-2 text-4xl text-sky-500'>
+                        <%= @latest_examination.test.decorate.implementation_year %>
+                    </div>
                     <div class='flex justify-around py-2'>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>共通</h3>
-                            <div class='text-3xl text-sky-500'><%=@latest_score.common_score %></div>
+                            <div class='text-3xl text-sky-500'><%= @latest_score.common_score %></div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>専門</h3>
-                            <% # TODO:scoreテーブルにspecial_scoreのカラムを作成する %>
+# TODO: scoreテーブルにspecial_scoreのカラムを作成する %>
                             <div class='text-3xl text-sky-500'>専門</div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>実地</h3>
-                            <div class='text-3xl text-sky-500'><%=@latest_score.practical_score %></div>
+                            <div class='text-3xl text-sky-500'><%= @latest_score.practical_score %></div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>総得点</h3>
-                            <div class='text-3xl text-sky-500'><%=@latest_score.total_score %></div>
+                            <div class='text-3xl text-sky-500'><%= @latest_score.total_score %></div>
                         </div>
                         <div class='flex flex-col items-center px-8'>
                             <h3 class='text-3xl text-gray-500'>合格点</h3>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -5,7 +5,7 @@
             <div class='w-full h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden shadow-xl'>
                 <div class='m-5'>
                     <h2 class='font-bold text-xl'>前回のレポート</h2>
-                    <div class='text-center underline my-2 text-4xl text-sky-500'>実施年度</div>
+                    <div class='text-center my-2 text-4xl text-sky-500'><%= @latest_examination.test.decorate.implementation_year %></div>
                     <div class='flex justify-around py-2'>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>共通</h3>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -9,23 +9,24 @@
                     <div class='flex justify-around py-2'>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>共通</h3>
-                            <div class='text-3xl text-sky-500'>得点</div>
+                            <div class='text-3xl text-sky-500'><%=@latest_score.common_score %></div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>専門</h3>
-                            <div class='text-3xl text-sky-500'>得点</div>
+                            <% # TODO:scoreテーブルにspecial_scoreのカラムを作成する %>
+                            <div class='text-3xl text-sky-500'>専門</div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>実地</h3>
-                            <div class='text-3xl text-sky-500'>得点</div>
+                            <div class='text-3xl text-sky-500'><%=@latest_score.practical_score %></div>
                         </div>
                         <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
                             <h3 class='text-3xl text-gray-500'>総得点</h3>
-                            <div class='text-3xl text-sky-500'>得点</div>
+                            <div class='text-3xl text-sky-500'><%=@latest_score.total_score %></div>
                         </div>
                         <div class='flex flex-col items-center px-8'>
                             <h3 class='text-3xl text-gray-500'>合格点</h3>
-                            <div class='text-3xl text-sky-500'>得点</div>
+                            <div class='text-3xl text-sky-500'><%= @latest_examination.test.pass_mark.total_score %></div>
                         </div>
                     </div>
                 </div>

--- a/db/fixtures/development/07_examination.rb
+++ b/db/fixtures/development/07_examination.rb
@@ -1,0 +1,6 @@
+Examination.seed(:id, [
+  { id: 1, user_id: 1, test_id: 1, attempt_date: Time.current, created_at: Time.current },
+  { id: 2, user_id: 1, test_id: 2, attempt_date: Time.current - 1.year, created_at: Time.current },
+  { id: 3, user_id: 2, test_id: 1, attempt_date: Time.current - 2.months, created_at: Time.current },
+  { id: 4, user_id: 2, test_id: 2, attempt_date: Time.current - 6.months, created_at: Time.current }
+])

--- a/db/fixtures/development/08_score.rb
+++ b/db/fixtures/development/08_score.rb
@@ -1,0 +1,6 @@
+Score.seed(:id, [
+  { id: 1, examination_id: 1, common_score: 45, practical_score: 35, total_score: 80, created_at: Time.current },
+  { id: 2, examination_id: 2, common_score: 40, practical_score: 35, total_score: 75, created_at: Time.current },
+  { id: 3, examination_id: 3, common_score: 50, practical_score: 40, total_score: 90, created_at: Time.current },
+  { id: 4, examination_id: 4, common_score: 45, practical_score: 40, total_score: 85, created_at: Time.current }
+])

--- a/spec/factories/pass_marks.rb
+++ b/spec/factories/pass_marks.rb
@@ -20,6 +20,8 @@
 #
 FactoryBot.define do
   factory :pass_mark do
-    
+    required_practical_score { rand(0..50) }
+    required_score { rand(150..180) }
+    total_score { 1 }
   end
 end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -2,10 +2,19 @@ require 'rails_helper'
 
 RSpec.describe "Dashboards", type: :request do
   describe "GET /index" do
+    let(:user) { create(:user) }
+    let(:test){ create(:test)}
+    let!(:pass_mark) { create(:pass_mark, test: ) }
+    let!(:examination) { create(:examination, test: , user: ) }
+    let!(:score) { create(:score, examination: ) }
+
+    before do
+      sign_in user
+    end
+
     it "returns http success" do
       get "/dashboard"
       expect(response).to have_http_status(:success)
     end
   end
-
 end


### PR DESCRIPTION
対応するissue
---
close #30

概要
---

`examination`の履歴から前回の`score`を取得してdashboardに表示できるようにしました。

エンドポイント
---

新たに実装したルーティングはなし


UI の比較
----

| 現状 | figma | 
|:------:|:------:|
| <a href="https://gyazo.com/c084531552181656b94f8624a41b4e2b"><img src="https://i.gyazo.com/c084531552181656b94f8624a41b4e2b.png" alt="Image from Gyazo" width="300"/></a> | <a href="https://gyazo.com/4d332552953d67a270ecb8347ca52456"><img src="https://i.gyazo.com/4d332552953d67a270ecb8347ca52456.png" alt="Image from Gyazo" width="300"/></a> | 



実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- なし

備考
---

その他になにかあれば