### PR TITLE
]専門の表示を削除してレイアウトを修正

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -8,26 +8,21 @@
                     <div class='text-center my-2 text-4xl text-sky-500'>
                         <%= @latest_examination.test.decorate.implementation_year %>
                     </div>
-                    <div class='flex justify-around py-2'>
-                        <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500'>共通</h3>
+                    <div class='flex justify-center py-2'>
+                        <div class='flex flex-col text-center border-r-4 border-gray-200'>
+                            <h3 class='text-3xl text-gray-500 mx-8'>共通</h3>
                             <div class='text-3xl text-sky-500'><%= @latest_score.common_score %></div>
                         </div>
-                        <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500'>専門</h3>
-                            <%# TODO: scoreテーブルにspecial_scoreのカラムを作成する %>
-                            <div class='text-3xl text-sky-500'>専門</div>
-                        </div>
-                        <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500'>実地</h3>
+                        <div class='flex flex-col text-center border-r-4 border-gray-200'>
+                            <h3 class='text-3xl text-gray-500 mx-8'>実地</h3>
                             <div class='text-3xl text-sky-500'><%= @latest_score.practical_score %></div>
                         </div>
-                        <div class='flex flex-col items-center px-8 border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500'>総得点</h3>
+                        <div class='flex flex-col text-center border-r-4 border-gray-200'>
+                            <h3 class='text-3xl text-gray-500 mx-8'>総得点</h3>
                             <div class='text-3xl text-sky-500'><%= @latest_score.total_score %></div>
                         </div>
-                        <div class='flex flex-col items-center px-8'>
-                            <h3 class='text-3xl text-gray-500'>合格点</h3>
+                        <div class='flex flex-col text-center'>
+                            <h3 class='text-3xl text-gray-500 mx-8'>合格点</h3>
                             <div class='text-3xl text-sky-500'><%= @latest_examination.test.pass_mark.total_score %></div>
                         </div>
                     </div>


### PR DESCRIPTION
対応するissue
---
close #42

概要
---

専門の表示を削除してレイアウトを修正

UI の比較
----

| 現状 | figma | 
|:------:|:------:|
| <a href="https://gyazo.com/1dbbfe4e8d19a8fa33e879304dcbbb22"><img src="https://i.gyazo.com/1dbbfe4e8d19a8fa33e879304dcbbb22.png" alt="Image from Gyazo" width="600"/></a> | <a href="https://gyazo.com/0b99e3a941a0013abbd9073faf1bdb5d"><img src="https://i.gyazo.com/0b99e3a941a0013abbd9073faf1bdb5d.png" alt="Image from Gyazo" width="609"/></a> | 
