### PR TITLE
dashboardにタグのボタンを表示する

### DIFF
--- a/app/controllers/tests/selections_controller.rb
+++ b/app/controllers/tests/selections_controller.rb
@@ -1,5 +1,5 @@
 class Tests::SelectionsController < ApplicationController
   def index
-    @test = Test.all
+    @tests = Test.all
   end
 end

--- a/app/controllers/tests/selections_controller.rb
+++ b/app/controllers/tests/selections_controller.rb
@@ -1,5 +1,5 @@
 class Tests::SelectionsController < ApplicationController
   def index
-    @tests = Test.all
+    @tests = Test.all.decorate
   end
 end

--- a/app/controllers/tests/selections_controller.rb
+++ b/app/controllers/tests/selections_controller.rb
@@ -1,5 +1,8 @@
 class Tests::SelectionsController < ApplicationController
   def index
     @tests = Test.all.decorate
+    @common_tags = Tag.common_tags
+    @special_tags = Tag.special_tags
+    @major_categorys = Tag.major_category
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -16,4 +16,8 @@ class Tag < ApplicationRecord
   has_many :questions, through: :question_tags
 
   validates :name, presence: true, uniqueness: true
+
+  scope :common_tags, -> { where(id: 4..13) }
+  scope :special_tags, -> { where(id: 14..26) }
+  scope :major_category, -> { where(id: 1..3) }
 end

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -20,7 +20,7 @@
 
           <div class='mt-3 grid grid-cols-4 gap-3'>
             <% @tests.each do |test| %>
-              <%= button_to "第#{test.id}回（#{test.year}年度）", test_path(test.id),
+              <%= button_to "第#{test.turn}回（#{test.year}年度）", test_path(test.id),
                             class: 'bg-stone-100 text-sky-500 hover:bg-sky-500 hover:text-stone-300 font-bold
                             py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
             <% end %>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -18,10 +18,12 @@
             <h2 class='font-bold text-xl text-gray-900 ml-3'>年度から選択</h2>
           </div>
 
-          <div class='mt-3 grid gap-3'>
-            <%= button_to '第58回（2023年度）', test_path(1),
-                          class: 'mt-3 bg-stone-100 text-sky-500 hover:bg-sky-500 hover:text-stone-300 font-bold
-                          py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+          <div class='mt-3 grid grid-cols-4 gap-3'>
+            <% @tests.each do |test| %>
+              <%= button_to "第#{test.id}回（#{test.year}年度）", test_path(test.id),
+                            class: 'bg-stone-100 text-sky-500 hover:bg-sky-500 hover:text-stone-300 font-bold
+                            py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -21,7 +21,7 @@
           <div class='mt-3 grid grid-cols-4 gap-3'>
             <% @tests.each do |test| %>
               <%= button_to "第#{test.turn}回（#{test.year}年度）", test_path(test.id),
-                            class: 'bg-stone-100 text-sky-500 hover:bg-sky-500 hover:text-stone-300 font-bold
+                            class: 'bg-sky-100 text-gray-800 hover:bg-sky-500 font-bold
                             py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
             <% end %>
           </div>
@@ -35,10 +35,36 @@
             <h2 class='font-bold text-xl text-gray-900 ml-3'>タグから選択</h2>
           </div>
 
-          <div class='mt-3 grid gap-3'>
-            <%= button_to '解剖学', '#',
-                          class: 'mt-3 bg-stone-100 text-purple-500 hover:bg-purple-500 hover:text-stone-200 font-bold
-                          py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+          <div class='mt-3'>
+            <div class='flex flex-wrap justify-start'>
+              <% @major_categorys.each do |tag| %>
+                <div class='mt-3 mr-2'>
+                  <%= button_to tag.name, '#',
+                                class: 'bg-amber-100 text-gray-800 hover:bg-amber-400 font-bold
+                                py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+                </div>
+              <% end %>
+            </div>
+
+            <div class='flex flex-wrap justify-start'>
+              <% @common_tags.each do |tag| %>
+                <div class='mt-3 mr-2'>
+                  <%= button_to tag.name, '#',
+                                class: 'bg-green-100 text-gray-800 hover:bg-green-400 font-bold
+                                py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+                </div>
+              <% end %>
+            </div>
+
+            <div class='flex flex-wrap justify-start'>
+              <% @special_tags.each do |tag| %>
+                <div class='mt-3 mr-2'>
+                  <%= button_to tag.name, '#',
+                                class: 'bg-blue-100 text-gray-800 hover:bg-blue-300 font-bold
+                                py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+                </div>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>

--- a/db/fixtures/development/10_tag.rb
+++ b/db/fixtures/development/10_tag.rb
@@ -1,4 +1,4 @@
-Tags.seed(:id, [
+Tag.seed(:id, [
   { id: 1, name: '共通問題' },
   { id: 2, name: '専門問題' },
   { id: 3, name: '実地問題' },


### PR DESCRIPTION
対応するissue
---
close #56

概要
---

タグのボタンを表示させた
区分ごとに表示させたかったのでscopeを設定して区分した
pathは設定していない
みやすくするためにfigmaとは少し変えた


UI の比較
----

| 現状 | figma | 
|:------:|:------:|
| <a href="https://gyazo.com/6ffbe09790fe3a9d4edc20f56176d8da"><img src="https://i.gyazo.com/6ffbe09790fe3a9d4edc20f56176d8da.gif" alt="Image from Gyazo" width="300"/></a> | <a href="https://gyazo.com/477c83491abf87fccc88a3715fae2aea"><img src="https://i.gyazo.com/477c83491abf87fccc88a3715fae2aea.png" alt="Image from Gyazo" width="300"/></a> | 



実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- なし

備考
---

なし