### PR TITLE
score計算のエラーを修正

### DIFF
--- a/app/decorators/question_decorator.rb
+++ b/app/decorators/question_decorator.rb
@@ -4,9 +4,9 @@ class QuestionDecorator < Draper::Decorator
   # Define presentation-specific methods here. Helpers are accessed through
   # `helpers` (aka `h`). You can override attributes, for example:
   #
-  def incorrect_color(examination)
+  def result_color(examination)
     return 'text-red-300' if selected_option_numbers(examination).empty?
 
-    selected_option_numbers(examination).sort == correct_option_numbers.sort ? '' : 'text-red-300'
+    selected_option_numbers(examination).sort == correct_option_numbers.sort ? 'text-gray-800' : 'text-red-300'
   end
 end

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -31,6 +31,8 @@ class Score < ApplicationRecord
     end
 
     def call
+      correct_responses
+
       Score.create!(
         examination_id: @examination.id,
         common_score:,

--- a/app/views/examinations/_question_table.html.erb
+++ b/app/views/examinations/_question_table.html.erb
@@ -10,7 +10,7 @@
     <% questions.each do |question| %>
       <tr>
         <!-- 問題番号 -->
-        <td class="border border-gray-300 px-2 py-1 w-20 <%= question.decorate.incorrect_color(examination) %>">
+        <td class="border border-gray-300 px-2 py-1 w-20 <%= question.decorate.result_color(examination) %>">
           <%= test.decorate.question_code_without_turn(question) %>
         </td>
 

--- a/spec/decorators/question_decorator_spec.rb
+++ b/spec/decorators/question_decorator_spec.rb
@@ -1,28 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe QuestionDecorator do
-  describe '#incorrect_color(examination)' do
+  describe '#result_color(examination)' do
     let(:examination) { create(:examination) }
     let(:question) { create(:question).decorate }
 
     context '未回答の場合' do
       it '赤色を返す' do
         allow(question).to receive(:selected_option_numbers).with(examination).and_return([])
-        expect(question.incorrect_color(examination)).to eq 'text-red-300'
+        expect(question.result_color(examination)).to eq 'text-red-300'
       end
     end
 
     context '回答がある場合' do
-      it '回答が正解の場合は空文字を返す' do
+      it '回答が正解の場合はtext-gray-800を返す' do
         allow(question).to receive(:selected_option_numbers).with(examination).and_return([1, 2])
         allow(question).to receive(:correct_option_numbers).and_return([1, 2])
-        expect(question.incorrect_color(examination)).to eq ''
+        expect(question.result_color(examination)).to eq 'text-gray-800'
       end
 
       it '回答が不正解の場合は赤色を返す' do
         allow(question).to receive(:selected_option_numbers).with(examination).and_return([1, 3])
         allow(question).to receive(:correct_option_numbers).and_return([1, 2])
-        expect(question.incorrect_color(examination)).to eq 'text-red-300'
+        expect(question.result_color(examination)).to eq 'text-red-300'
       end
     end
   end


### PR DESCRIPTION
対応するissue
---
close #58

概要
---

~~~ruby
[1m[36mUserResponse Bulk Insert (0.8ms)[0m  [1m[32mINSERT INTO `user_responses` (`examination_id`,`choice_id`,`created_at`,`updated_at`) VALUES (8, 1, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)), (8, 6, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)), (8, 11, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)), (8, 21, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)), (8, 26, CURRENT_TIMESTAMP(6), CURRENT_TIMESTAMP(6)) ON DUPLICATE KEY UPDATE `examination_id`=`examination_id`[0m
  ↳ app/models/user_response.rb:45:in `bulk_create_responses'
試験結果の保存エラー: undefined method `count' for nil
~~~
上記のエラーを解消しました。
また、解答確認画面で不正解の場合の色が反映されない場合があるのでこれも修正しました

実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- なし

備考
---

なし