### PR TITLE
試験画面内のそれぞれの問題にタグを表示する

### DIFF
--- a/app/controllers/tests_controller.rb
+++ b/app/controllers/tests_controller.rb
@@ -3,7 +3,7 @@ class TestsController < ApplicationController
     @test = Test.find(params[:id]).decorate
     @test_sessions = @test.test_sessions.includes(questions: :choices)
     # 各TestSessionに紐づくquestionsを全て取得する
-    @questions = @test_sessions.flat_map(&:questions)
+    @questions = @test_sessions.flat_map { |session| session.questions.decorate }
     # 解答を保持するためにuser_responseを持たせたいが、初回にエラーが出ないように空配列を渡す
     @user_responses = []
   end

--- a/app/decorators/question_decorator.rb
+++ b/app/decorators/question_decorator.rb
@@ -1,9 +1,5 @@
 class QuestionDecorator < Draper::Decorator
   delegate_all
-
-  # Define presentation-specific methods here. Helpers are accessed through
-  # `helpers` (aka `h`). You can override attributes, for example:
-  #
   def result_color(examination)
     return 'text-red-300' if selected_option_numbers(examination).empty?
 

--- a/app/decorators/tag_decorator.rb
+++ b/app/decorators/tag_decorator.rb
@@ -1,0 +1,13 @@
+class TagDecorator < Draper::Decorator
+  delegate_all
+
+  def category_color
+    if Tag.major_category.exists?(id)
+      'bg-amber-100'
+    elsif Tag.special_tags.exists?(id)
+      'bg-blue-100'
+    else
+      'bg-green-100'
+    end
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -21,6 +21,8 @@
 class Question < ApplicationRecord
   belongs_to :test_session
   has_many :choices, dependent: :destroy
+  has_many :question_tags, dependent: :destroy
+  has_many :tags, through: :question_tags
 
   validates :content, presence: true
   validates :question_number, presence: true
@@ -32,7 +34,6 @@ class Question < ApplicationRecord
   # questionに対応する回答を取得する
   def selected_option_numbers(examination)
     user_responses = examination.user_responses.select { |response| response.choice.question_id == id }
-    # 回答があれば配列で返し、未回答の場合は空の配列を返す
-    user_responses.map { |response| response.choice.option_number } # choiceのoption_numberを返す
+    user_responses.map { |response| response.choice.option_number }
   end
 end

--- a/app/views/tests/show.html.erb
+++ b/app/views/tests/show.html.erb
@@ -12,7 +12,7 @@
               <div><%= @test.decorate.question_code(question) %></div>
               <div class='flex'>
                 <% question.tags.each do |tag| %>
-                  <span class='rounded-full p-2 <%= tag.decorate.category_color %>'><%= tag.name %></span>
+                  <span class='rounded-full p-2 mx-1 <%= tag.decorate.category_color %>'><%= tag.name %></span>
                 <% end %>
               </div>
             </div>
@@ -40,7 +40,9 @@
                                         id: "select-#{question.id}-#{index + 1}",
                                         class: 'w-4 h-4 bg-gray-100 border-gray-300 rounded focus:ring-blue-500' %>
                       <label for='select-<%= question.id %>-<%= index + 1 %>'>
-                        <span class="w-full py-3 ms-2 text-base font-medium text-gray-900"><%= choice.option_number %>. <%= choice.content %></span>
+                        <span class="w-full py-3 ms-2 text-base font-medium text-gray-900">
+                          <%= choice.option_number %>. <%= choice.content %>
+                        </span>
                       </label>
                     </div>
                   </li>

--- a/app/views/tests/show.html.erb
+++ b/app/views/tests/show.html.erb
@@ -8,7 +8,14 @@
         <div class='w-full h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden shadow-xl'>
           <div class='m-5'>
             <!-- 問題番号 -->
-            <div class='font-bold'><%= @test.decorate.question_code(question) %></div>
+            <div class='flex items-center font-bold space-x-2 justify-between'>
+              <div><%= @test.decorate.question_code(question) %></div>
+              <div class='flex'>
+                <% question.tags.each do |tag| %>
+                  <span class='rounded-full p-2 <%= tag.decorate.category_color %>'><%= tag.name %></span>
+                <% end %>
+              </div>
+            </div>
             <!-- 問題文 -->
             <div class='m-5'>
               <%= question.content %>
@@ -33,7 +40,7 @@
                                         id: "select-#{question.id}-#{index + 1}",
                                         class: 'w-4 h-4 bg-gray-100 border-gray-300 rounded focus:ring-blue-500' %>
                       <label for='select-<%= question.id %>-<%= index + 1 %>'>
-                        <span class="w-full py-3 ms-2 text-base font-medium text-gray-900"><%= choice.content %></span>
+                        <span class="w-full py-3 ms-2 text-base font-medium text-gray-900"><%= choice.option_number %>. <%= choice.content %></span>
                       </label>
                     </div>
                   </li>

--- a/spec/decorators/tag_decorator_spec.rb
+++ b/spec/decorators/tag_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe TagDecorator do
+end

--- a/spec/decorators/tag_decorator_spec.rb
+++ b/spec/decorators/tag_decorator_spec.rb
@@ -1,4 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe TagDecorator do
+  describe '#category_color' do
+    subject { tag.decorate.category_color }
+    context 'major_categoryの場合' do
+      let(:tag) { create(:tag, :major_category) }
+      it 'bg-amber-100を返す' do
+        expect(subject).to eq('bg-amber-100')
+      end
+    end
+
+    context 'special_tagsの場合' do
+      let(:tag) { create(:tag, :special_tags) }
+      it 'bg-blue-100を返す' do
+        expect(subject).to eq('bg-blue-100')
+      end
+    end
+
+    context 'common_tagsの場合' do
+      let(:tag) { create(:tag, :common_tags) }
+      it 'bg-green-100を返す' do
+        expect(subject).to eq('bg-green-100')
+      end
+    end
+  end
 end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -14,5 +14,17 @@
 FactoryBot.define do
   factory :tag do
     name { Faker::Lorem.word }
+
+    trait :major_category do
+      id { 1 }
+    end
+
+    trait :common_tags do
+      id { 4 }
+    end
+
+    trait :special_tags do
+      id { 14 }
+    end
   end
 end


### PR DESCRIPTION
対応するissue
---
close #61

概要
---

tagでの絞り込み機能作成時にわかりやすいようにそれぞれの問題ごとにtagを表示するようにしました。


UI の比較
----

| 現状 | figma | 
|:------:|:------:|
| [<a href="https://gyazo.com/c3a981aa44279791f696eaf3b278d28f"><img src="https://i.gyazo.com/c3a981aa44279791f696eaf3b278d28f.png" alt="Image from Gyazo" width="300"/></a>](https://gyazo.com/dd37dbfc9d38f2f4910f5425639660b4) | <a href="https://gyazo.com/ead4ace1ca3ebf1c6feb49f29e012f40"><img src="https://i.gyazo.com/ead4ace1ca3ebf1c6feb49f29e012f40.png" alt="Image from Gyazo" width="300"/></a> | 



実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- 追加した gem があれば url を添えて書いてください

備考
---

その他になにかあれば