### PR TITLE
ミニテスト機能を実装

### DIFF
--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,5 +1,6 @@
 class MiniTestsController < ApplicationController
   def index
+    # TODO: Formオブジェクト化する
     tag_ids = params[:tag_ids] || []
     # タグに基づいて質問のIDリストを配列で取得
     question_ids = Question.joins(:question_tags)

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,13 +1,21 @@
 class MiniTestsController < ApplicationController
   def index
-    # 問題数も選択できるようにする
-    # 　必要なメソッドはモデルに移す
-    @questions = if params[:tag_ids].present?
-                   tag_ids = params[:tag_ids]
-                   Question.joins(:question_tags)
-                           .where(question_tags: { tag_id: tag_ids })
-                           .distinct
-                 end
+    tag_ids = params[:tag_ids] || []
+    # タグに基づいて質問を取得
+    @questions = Question.joins(:question_tags)
+                         .where(question_tags: { tag_id: tag_ids })
+                         .distinct
+
+    # 質問のIDリストを取得
+    question_ids = @questions.pluck(:id) # IDの配列を取得
+
+    # ランダムに選択する問題数を取得
+    question_count = params[:question_count].to_i
+
+    # ランダムに指定された数のIDを選択
+    random_ids = question_ids.sample(question_count)
+    @questions = @questions.where(id: random_ids) # 選択したIDに基づいて質問をフィルタリング
+
     @user_responses = []
   end
 end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,20 +1,14 @@
 class MiniTestsController < ApplicationController
   def index
     tag_ids = params[:tag_ids] || []
-    # タグに基づいて質問を取得
-    @questions = Question.joins(:question_tags)
-                         .where(question_tags: { tag_id: tag_ids })
-                         .distinct
-
-    # 質問のIDリストを取得
-    question_ids = @questions.pluck(:id) # IDの配列を取得
-
-    # ランダムに選択する問題数を取得
+    # タグに基づいて質問のIDリストを配列で取得
+    question_ids = Question.joins(:question_tags)
+                           .where(question_tags: { tag_id: tag_ids })
+                           .distinct
+                           .pluck(:id)
+    # ランダムに選択する問題数を指定
     question_count = params[:question_count].to_i
-
-    # ランダムに指定された数のIDを選択
-    random_ids = question_ids.sample(question_count)
-    @questions = @questions.where(id: random_ids) # 選択したIDに基づいて質問をフィルタリング
+    @questions = Question.random_questions(question_ids, question_count)
 
     @user_responses = []
   end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,0 +1,13 @@
+class MiniTestsController < ApplicationController
+  def index
+    # 問題数も選択できるようにする
+    # 　必要なメソッドはモデルに移す
+    @questions = if params[:tag_ids].present?
+                   tag_ids = params[:tag_ids]
+                   Question.joins(:question_tags)
+                           .where(question_tags: { tag_id: tag_ids })
+                           .distinct
+                 end
+    @user_responses = []
+  end
+end

--- a/app/controllers/tests/selections_controller.rb
+++ b/app/controllers/tests/selections_controller.rb
@@ -3,6 +3,6 @@ class Tests::SelectionsController < ApplicationController
     @tests = Test.all.decorate
     @common_tags = Tag.common_tags
     @special_tags = Tag.special_tags
-    @major_categorys = Tag.major_category
+    @major_categories = Tag.major_categories
   end
 end

--- a/app/controllers/tests/selections_controller.rb
+++ b/app/controllers/tests/selections_controller.rb
@@ -4,5 +4,14 @@ class Tests::SelectionsController < ApplicationController
     @common_tags = Tag.common_tags
     @special_tags = Tag.special_tags
     @major_categorys = Tag.major_category
+
+    @questions = if params[:tag_ids].present?
+                   tag_ids = params[:tag_ids]
+                   Question.joins(:question_tags)
+                           .where(question_tags: { tag_id: tag_ids })
+                           .distinct
+                 else
+                   Question.all
+                 end
   end
 end

--- a/app/controllers/tests/selections_controller.rb
+++ b/app/controllers/tests/selections_controller.rb
@@ -4,14 +4,5 @@ class Tests::SelectionsController < ApplicationController
     @common_tags = Tag.common_tags
     @special_tags = Tag.special_tags
     @major_categorys = Tag.major_category
-
-    @questions = if params[:tag_ids].present?
-                   tag_ids = params[:tag_ids]
-                   Question.joins(:question_tags)
-                           .where(question_tags: { tag_id: tag_ids })
-                           .distinct
-                 else
-                   Question.all
-                 end
   end
 end

--- a/app/decorators/mini_test_decorator.rb
+++ b/app/decorators/mini_test_decorator.rb
@@ -1,0 +1,12 @@
+class MiniTestDecorator < Draper::Decorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+end

--- a/app/decorators/tag_decorator.rb
+++ b/app/decorators/tag_decorator.rb
@@ -2,7 +2,7 @@ class TagDecorator < Draper::Decorator
   delegate_all
 
   def category_color
-    if Tag.major_category.exists?(id)
+    if Tag.major_categories.exists?(id)
       'bg-amber-100'
     elsif Tag.special_tags.exists?(id)
       'bg-blue-100'

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -36,4 +36,9 @@ class Question < ApplicationRecord
     user_responses = examination.user_responses.select { |response| response.choice.question_id == id }
     user_responses.map { |response| response.choice.option_number }
   end
+
+  def self.random_questions(question_ids, question_count)
+    random_ids = question_ids.sample(question_count)
+    where(id: random_ids)
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -19,5 +19,5 @@ class Tag < ApplicationRecord
 
   scope :common_tags, -> { where(id: 4..13) }
   scope :special_tags, -> { where(id: 14..26) }
-  scope :major_category, -> { where(id: 1..3) }
+  scope :major_categories, -> { where(id: 1..3) }
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -6,7 +6,7 @@
                 <div class='m-5'>
                     <h2 class='font-bold text-xl'>前回のスコア</h2>
                     <div class='text-center my-2 text-4xl text-sky-500'>
-                        <%= @latest_examination.test.decorate.implementation_year %>
+                        <%= @latest_examination&.test&.decorate&.implementation_year || '-' %>
                     </div>
                     <div class='flex justify-center py-2'>
                         <div class='flex flex-col text-center border-r-4 border-gray-200'>
@@ -23,7 +23,9 @@
                         </div>
                         <div class='flex flex-col text-center'>
                             <h3 class='text-3xl text-gray-500 mx-8'>合格点</h3>
-                            <div class='text-3xl text-sky-500'><%= @latest_examination.test.pass_mark.total_score || '-' %></div>
+                            <div class='text-3xl text-sky-500'>
+                                <%= @latest_examination&.test&.pass_mark&.total_score || '-' %>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,0 +1,10 @@
+<%= form_with url: user_responses_path, method: :post do |f| %>
+  <%# mini_testフラグを持たせる %>
+  <%# = hidden_field_tag :test_id, @test.id %>
+  <%= render 'tests/question', question: @question %>
+  <div class="text-center justify-center">
+    <%= f.submit 'テストを終了する',
+                 class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
+                    font-bold py-2 px-4 rounded-lg shadow-xl' %>
+  </div>
+<% end %>

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,7 +1,7 @@
 <%= form_with url: user_responses_path, method: :post do |f| %>
   <%# mini_testフラグを持たせる %>
   <%# = hidden_field_tag :test_id, @test.id %>
-  <%= render 'tests/question', question: @question %>
+  <%= render 'tests/question', question: @questions %>
   <div class="text-center justify-center">
     <%= f.submit 'テストを終了する',
                  class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -35,7 +35,7 @@
             <h2 class='font-bold text-xl text-gray-900 ml-3'>タグから選択</h2>
           </div>
           <div class='mt-3'>
-            <%= form_with url: mini_tests_index_path, method: :get do |f| %>
+            <%= form_with url: mini_tests_path, method: :get do |f| %>
               <h3 class='font-bold text-gray-900'>問題数を選択</h3>
               <div class='flex flex-wrap justify-start'>
                 <div class='mr-4'>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -34,40 +34,48 @@
             <%= image_tag 'tag.png', size: 50 %>
             <h2 class='font-bold text-xl text-gray-900 ml-3'>タグから選択</h2>
           </div>
-
           <div class='mt-3'>
-            <%= form_with url: tests_select_path, method: :get, local: false, data: { turbo: true } do |f| %>
-              <div class='flex flex-wrap justify-start'>
-                <% @major_categorys.each do |tag| %>
-                  <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold
+            <%= form_with url: mini_tests_index_path, method: :get, local: false, data: { turbo: true } do |f| %>
+                <h3 class='font-bold text-gray-900'>大分類から選択</h3>
+                <div class='flex flex-wrap justify-start'>
+                  <% @major_categorys.each do |tag| %>
+                    <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold
+                                py-2 px-4 shadow-xl text-center'>
+                      <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                      <%= label_tag "tag_#{tag.id}", tag.name %>
+                    </div>
+                  <% end %>
+                </div>
+                <h3 class='font-bold text-gray-900 mt-3'>共通問題から選択</h3>
+                <div class='flex flex-wrap justify-start'>
+                  <% @common_tags.each do |tag| %>
+                    <div class='mt-3 mr-2 bg-green-100 text-gray-800 font-bold
+                                py-2 px-4 shadow-xl text-center'>
+                      <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                      <%= label_tag "tag_#{tag.id}", tag.name %>
+                    </div>
+                  <% end %>
+              </div>
+                <h3 class='font-bold text-gray-900 mt-3'>専門問題から選択</h3>
+                <div class='flex flex-wrap justify-start'>
+                  <% @special_tags.each do |tag| %>
+                    <div class='mt-3 mr-2 bg-blue-100 text-gray-800 font-bold
                               py-2 px-4 shadow-xl text-center'>
                     <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
                     <%= label_tag "tag_#{tag.id}", tag.name %>
                   </div>
-                <% end %>
-                <% @common_tags.each do |tag| %>
-                  <div class='mt-3 mr-2 bg-green-100 text-gray-800 font-bold
-                              py-2 px-4 shadow-xl text-center'>
-                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
-                    <%= label_tag "tag_#{tag.id}", tag.name %>
-                  </div>
-                <% end %>
-                <% @special_tags.each do |tag| %>
-                  <div class='mt-3 mr-2 bg-blue-100 text-gray-800 font-bold
-                              py-2 px-4 shadow-xl text-center'>
-                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
-                    <%= label_tag "tag_#{tag.id}", tag.name %>
-                  </div>
-                <% end %>
-                <div class='mt-3'>
-                  <%= f.submit '検索', class: 'bg-blue-500 text-white rounded-lg py-2 px-4' %>
-                  <%= link_to 'クリア', tests_select_path, class: 'bg-gray-300 text-black rounded-lg py-2 px-4 ml-2' %>
+                  <% end %>
+                </div>
+                <div class='mt-3 flex justify-center'>
+                  <%= f.submit '小テストを始める',
+                               class: 'bg-orange-300 text-gray-100 hover:bg-sky-500
+                                       hover:text-orange-300 font-bold py-2 px-4 rounded-lg' %>
+                  <%= link_to '条件をクリア', tests_select_path,
+                              class: 'bg-gray-500 text-gray-100 hover:bg-gray-500
+                                      hover:text-red-300 font-bold py-2 px-4 ml-2 rounded-lg' %>
                 </div>
               </div>
             <% end %>
-            <div id="search-results" class="mt-3" data-turbo-action="replace">
-              <%= @questions.count %>
-            </div>
             </div>
           </div>
         </div>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -36,34 +36,37 @@
           </div>
 
           <div class='mt-3'>
-            <div class='flex flex-wrap justify-start'>
-              <% @major_categorys.each do |tag| %>
-                <div class='mt-3 mr-2'>
-                  <%= button_to tag.name, '#',
-                                class: 'bg-amber-100 text-gray-800 hover:bg-amber-400 font-bold
-                                py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
+            <%= form_with url: tests_select_path, method: :get, local: false, data: { turbo: true } do |f| %>
+              <div class='flex flex-wrap justify-start'>
+                <% @major_categorys.each do |tag| %>
+                  <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold
+                              py-2 px-4 shadow-xl text-center'>
+                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= label_tag "tag_#{tag.id}", tag.name %>
+                  </div>
+                <% end %>
+                <% @common_tags.each do |tag| %>
+                  <div class='mt-3 mr-2 bg-green-100 text-gray-800 font-bold
+                              py-2 px-4 shadow-xl text-center'>
+                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= label_tag "tag_#{tag.id}", tag.name %>
+                  </div>
+                <% end %>
+                <% @special_tags.each do |tag| %>
+                  <div class='mt-3 mr-2 bg-blue-100 text-gray-800 font-bold
+                              py-2 px-4 shadow-xl text-center'>
+                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= label_tag "tag_#{tag.id}", tag.name %>
+                  </div>
+                <% end %>
+                <div class='mt-3'>
+                  <%= f.submit '検索', class: 'bg-blue-500 text-white rounded-lg py-2 px-4' %>
                 </div>
-              <% end %>
+              </div>
+            <% end %>
+            <div id="search-results" class="mt-3" data-turbo-action="replace">
+              <%= @questions.count %>
             </div>
-
-            <div class='flex flex-wrap justify-start'>
-              <% @common_tags.each do |tag| %>
-                <div class='mt-3 mr-2'>
-                  <%= button_to tag.name, '#',
-                                class: 'bg-green-100 text-gray-800 hover:bg-green-400 font-bold
-                                py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
-                </div>
-              <% end %>
-            </div>
-
-            <div class='flex flex-wrap justify-start'>
-              <% @special_tags.each do |tag| %>
-                <div class='mt-3 mr-2'>
-                  <%= button_to tag.name, '#',
-                                class: 'bg-blue-100 text-gray-800 hover:bg-blue-300 font-bold
-                                py-2 px-4 rounded-full shadow-xl text-center', method: :get %>
-                </div>
-              <% end %>
             </div>
           </div>
         </div>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -36,47 +36,56 @@
           </div>
           <div class='mt-3'>
             <%= form_with url: mini_tests_index_path, method: :get, local: false, data: { turbo: true } do |f| %>
-                <h3 class='font-bold text-gray-900'>大分類から選択</h3>
-                <div class='flex flex-wrap justify-start'>
-                  <% @major_categorys.each do |tag| %>
-                    <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold
-                                py-2 px-4 shadow-xl text-center'>
-                      <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
-                      <%= label_tag "tag_#{tag.id}", tag.name %>
-                    </div>
-                  <% end %>
+              <h3 class='font-bold text-gray-900'>問題数を選択</h3>
+              <div class='flex flex-wrap justify-start'>
+                <div class='mr-4'>
+                  <%= radio_button_tag 'question_count', 10, false, id: 'question_count_10' %>
+                  <%= label_tag 'question_count_10', '10問' %>
                 </div>
-                <h3 class='font-bold text-gray-900 mt-3'>共通問題から選択</h3>
-                <div class='flex flex-wrap justify-start'>
-                  <% @common_tags.each do |tag| %>
-                    <div class='mt-3 mr-2 bg-green-100 text-gray-800 font-bold
-                                py-2 px-4 shadow-xl text-center'>
-                      <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
-                      <%= label_tag "tag_#{tag.id}", tag.name %>
-                    </div>
-                  <% end %>
+                <div class='mr-4'>
+                  <%= radio_button_tag 'question_count', 20, false, id: 'question_count_20' %>
+                  <%= label_tag 'question_count_20', '20問' %>
+                </div>
+                <div class='mr-4'>
+                  <%= radio_button_tag 'question_count', 30, false, id: 'question_count_30' %>
+                  <%= label_tag 'question_count_30', '30問' %>
+                </div>
               </div>
-                <h3 class='font-bold text-gray-900 mt-3'>専門問題から選択</h3>
-                <div class='flex flex-wrap justify-start'>
-                  <% @special_tags.each do |tag| %>
-                    <div class='mt-3 mr-2 bg-blue-100 text-gray-800 font-bold
-                              py-2 px-4 shadow-xl text-center'>
+
+              <h3 class='font-bold text-gray-900'>大分類から選択</h3>
+              <div class='flex flex-wrap justify-start'>
+                <% @major_categorys.each do |tag| %>
+                  <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
                     <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
                     <%= label_tag "tag_#{tag.id}", tag.name %>
                   </div>
-                  <% end %>
-                </div>
-                <div class='mt-3 flex justify-center'>
-                  <%= f.submit '小テストを始める',
-                               class: 'bg-orange-300 text-gray-100 hover:bg-sky-500
-                                       hover:text-orange-300 font-bold py-2 px-4 rounded-lg' %>
-                  <%= link_to '条件をクリア', tests_select_path,
-                              class: 'bg-gray-500 text-gray-100 hover:bg-gray-500
-                                      hover:text-red-300 font-bold py-2 px-4 ml-2 rounded-lg' %>
-                </div>
+                <% end %>
+              </div>
+              <h3 class='font-bold text-gray-900 mt-3'>共通問題から選択</h3>
+              <div class='flex flex-wrap justify-start'>
+                <% @common_tags.each do |tag| %>
+                  <div class='mt-3 mr-2 bg-green-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
+                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= label_tag "tag_#{tag.id}", tag.name %>
+                  </div>
+                <% end %>
+              </div>
+              <h3 class='font-bold text-gray-900 mt-3'>専門問題から選択</h3>
+              <div class='flex flex-wrap justify-start'>
+                <% @special_tags.each do |tag| %>
+                  <div class='mt-3 mr-2 bg-blue-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
+                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= label_tag "tag_#{tag.id}", tag.name %>
+                  </div>
+                <% end %>
+              </div>
+              <div class='mt-3 flex justify-center'>
+                <%= f.submit '小テストを始める',
+                             class: 'bg-orange-300 text-gray-100 hover:bg-sky-500 hover:text-orange-300 font-bold py-2 px-4 rounded-lg' %>
+                <%= link_to '条件をクリア', tests_select_path,
+                            class: 'bg-gray-500 text-gray-100 hover:bg-gray-500 hover:text-red-300 font-bold py-2 px-4 ml-2 rounded-lg' %>
               </div>
             <% end %>
-            </div>
           </div>
         </div>
       </div>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -1,6 +1,6 @@
 <div class='flex flex-wrap body-font'>
   <div class='w-full max-w-4xl m-auto'>
-   <div data-controller="tab" class='mb-10 mt-5'>
+    <div data-controller="tab" class='mb-10 mt-5'>
       <div class="flex">
         <button data-action="tab#showYearTypes" class='bg-sky-100 text-black font-bold py-2 px-4 rounded'>
           模試形式
@@ -35,7 +35,7 @@
             <h2 class='font-bold text-xl text-gray-900 ml-3'>タグから選択</h2>
           </div>
           <div class='mt-3'>
-            <%= form_with url: mini_tests_index_path, method: :get, local: false, data: { turbo: true } do |f| %>
+            <%= form_with url: mini_tests_index_path, method: :get do |f| %>
               <h3 class='font-bold text-gray-900'>問題数を選択</h3>
               <div class='flex flex-wrap justify-start'>
                 <div class='mr-4'>
@@ -80,10 +80,10 @@
                 <% end %>
               </div>
               <div class='mt-3 flex justify-center'>
-                <%= f.submit '小テストを始める',
-                             class: 'bg-orange-300 text-gray-100 hover:bg-sky-500 hover:text-orange-300 font-bold py-2 px-4 rounded-lg' %>
-                <%= link_to '条件をクリア', tests_select_path,
-                            class: 'bg-gray-500 text-gray-100 hover:bg-gray-500 hover:text-red-300 font-bold py-2 px-4 ml-2 rounded-lg' %>
+                <%= f.submit '小テストを始める', class: 'bg-orange-300 text-gray-100 hover:bg-sky-500
+                                                      hover:text-orange-300 font-bold py-2 px-4 rounded-lg' %>
+                <%= link_to '条件をクリア', tests_select_path, class: 'bg-gray-500 text-gray-100 hover:bg-gray-500
+                                                      hover:text-red-300 font-bold py-2 px-4 ml-2 rounded-lg' %>
               </div>
             <% end %>
           </div>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -61,6 +61,7 @@
                 <% end %>
                 <div class='mt-3'>
                   <%= f.submit '検索', class: 'bg-blue-500 text-white rounded-lg py-2 px-4' %>
+                  <%= link_to 'クリア', tests_select_path, class: 'bg-gray-300 text-black rounded-lg py-2 px-4 ml-2' %>
                 </div>
               </div>
             <% end %>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -54,7 +54,7 @@
 
               <h3 class='font-bold text-gray-900'>大分類から選択</h3>
               <div class='flex flex-wrap justify-start'>
-                <% @major_categorys.each do |tag| %>
+                <% @major_categories.each do |tag| %>
                   <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
                     <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
                     <%= label_tag "tag_#{tag.id}", tag.name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'mini_tests/index'
   require 'sidekiq/web'
     devise_for :users, controllers: {
     registrations: 'users/registrations',
@@ -17,6 +16,7 @@ Rails.application.routes.draw do
     get '/select' => 'selections#index'
   end
   get '/tests/:id' => 'tests#show', as: 'test'
+  get 'mini_tests' => 'mini_tests#index'
 
   resources :examinations do
     resources :scores, only: [:show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get 'mini_tests/index'
   require 'sidekiq/web'
     devise_for :users, controllers: {
     registrations: 'users/registrations',

--- a/spec/decorators/mini_test_decorator_spec.rb
+++ b/spec/decorators/mini_test_decorator_spec.rb
@@ -1,0 +1,4 @@
+require 'rails_helper'
+
+RSpec.describe MiniTestDecorator do
+end

--- a/spec/decorators/tag_decorator_spec.rb
+++ b/spec/decorators/tag_decorator_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe TagDecorator do
   describe '#category_color' do
     subject { tag.decorate.category_color }
-    context 'major_categoryの場合' do
-      let(:tag) { create(:tag, :major_category) }
+    context 'major_categoriesの場合' do
+      let(:tag) { create(:tag, :major_categories) }
       it 'bg-amber-100を返す' do
         expect(subject).to eq('bg-amber-100')
       end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
   factory :tag do
     name { Faker::Lorem.word }
 
-    trait :major_category do
+    trait :major_categories do
       id { 1 }
     end
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -56,4 +56,13 @@ RSpec.describe Question, type: :model do
       end
     end
   end
+
+  describe '#random_questions' do
+    let(:question_ids) { create_list(:question, 10).pluck(:id) }
+    let(:question_count) { 5 }
+
+    it '指定された数の質問がランダムに返される' do
+      expect(Question.random_questions(question_ids, question_count).count).to eq(question_count)
+    end
+  end
 end

--- a/spec/requests/mini_tests_spec.rb
+++ b/spec/requests/mini_tests_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "MiniTests", type: :request do
     
 
     it "returns http success" do
-      get "/mini_tests/index", params: { tag_ids: [tag.id] }
+      get "/mini_tests", params: { tag_ids: [tag.id] }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/mini_tests_spec.rb
+++ b/spec/requests/mini_tests_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "MiniTests", type: :request do
     
 
     it "returns http success" do
-      get "/mini_tests", params: { tag_ids: [tag.id] }
+      get "/mini_tests", params: { search: { tag_ids: [tag.id], question_count: 1 } }
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/mini_tests_spec.rb
+++ b/spec/requests/mini_tests_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "MiniTests", type: :request do
+  describe "GET /index" do
+    let(:test){create(:test)}
+    let(:test_session) {create(:test_session, test: test)}
+    let(:tag) {create(:tag)}
+    let!(:question) {create(:question, test_session: test_session)}
+    let!(:question_tag) { create(:question_tag, question: question, tag: tag) }
+    
+
+    it "returns http success" do
+      get "/mini_tests/index", params: { tag_ids: [tag.id] }
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
対応するissue
---
close #60

概要
---

小テストの絞り込み機能を実装しました。ransackを使用せず、直接SQLで絞り込んでいます。
問題の年度で絞る機能は別で実装します。（問題を１年分しかseedに入れてないので）

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `GET /mini_tests?~`| `mini_tests#index` | 小テスト画面を表示する |


UI
----
[![Image from Gyazo](https://i.gyazo.com/82464322a2cd4729cdb2097966220127.gif)](https://gyazo.com/82464322a2cd4729cdb2097966220127)



実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- なし

備考
---

なぜか2〜30回に１回くらい関係ないタグの問題が表示されます。原因わからず。。。
github actionsでのrspecもdb:createできないことが増えてきました....