### PR TITLE
robocopでspec配下を対象にして修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,29 +61,29 @@ Rails/I18nLocaleTexts:
 
 # RSpec関連の設定
 RSpec/AnyInstance:
-  Enabled: false  # allow_any_instance_ofの使用を禁止します。テストの可読性を向上させるために推奨されます。
+  Enabled: false  # allow_any_instance_ofの使用を許可。
 
 RSpec/ContextWording:
-  Enabled: false  # contextブロックの説明文が適切であるかをチェックしません。自由に記述できます。
+  Enabled: false  # contextブロックの説明文のチェックを無効化。
 
 RSpec/MultipleMemoizedHelpers:
-  Enabled: false  # 1つのテストで複数のletまたはlet!を使用することを許可します。柔軟性を持たせます。
+  Enabled: false  # 複数のletまたはlet!の使用を許可。
 
 RSpec/MultipleExpectations:
-  Enabled: false  # 1つのテスト内で複数のexpectを使用することを許可します。テストの複雑さを増す可能性がありますが、便利です。
+  Enabled: false  # 複数のexpectの使用を許可。
 
 Lint/MissingSuper:
   Exclude:
-    - 'app/components/**/*'  # オーバーライドされたメソッドでsuperを呼び出さない場合に警告を出しますが、特定のディレクトリは除外します。
+    - 'app/components/**/*'  # superを呼び出さないオーバーライドメソッドの警告を特定ディレクトリで無効化。
 
 RSpec/ExampleLength:
-  Enabled: false  # テストの例（itブロック）の長さを制限しません。長いテストも許可されます。
+  Enabled: false  # テストの例の長さ制限を無効化。
 
 RSpec/NestedGroups:
-  Enabled: false  # ネストされたdescribeやcontextグループの使用を許可します。テストの構造を柔軟にします。
+  Enabled: false  # ネストされたdescribeやcontextグループの使用を許可。
 
 RSpec/LetSetup:
-  Enabled: false  # letを使用する際のセットアップが適切であるかをチェックしません。自由に使用できます。
+  Enabled: false  # letのセットアップチェックを無効化。
 
 RSpec/NamedSubject:
-  Enabled: false  # subjectに名前を付けることを推奨しません。名前を付けなくても警告は表示されません。
+  Enabled: false  # subjectに名前を付けることを強制しない。

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,32 +20,70 @@ AllCops:
     - 'vendor/**/*'
     - 'db/**/*'
     - 'bin/**/*'
-    - 'spec/**/*'
+    - 'tmp/**/*'
     - 'config/**/*'
     - 'lib/tasks/auto_annotate_models.rake'
+# Rails: Rails関連のルールを有効にする
 Rails:
   Enabled: true
 
+# Metrics/AbcSize: メソッドの複雑さの最大値を25に設定
 Metrics/AbcSize:
   Max: 25
 
+# Style/AsciiComments: ASCIIコメントのスタイルチェックを無効にする
 Style/AsciiComments:
   Enabled: false
 
+# Style/ClassAndModuleChildren: クラスとモジュールの子要素のスタイルチェックを無効にする
 Style/ClassAndModuleChildren:
   Enabled: false
 
+# Style/Documentation: ドキュメンテーションスタイルチェックを無効にする
 Style/Documentation:
   Enabled: false
 
+# Naming/PredicateName: プレディケート名のスタイルチェックを無効にする
 Naming/PredicateName:
   Enabled: false
 
+# Style/FrozenStringLiteralComment: フローズン文字列リテラルコメントのスタイルチェックを無効にする
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+# Style/StringLiterals: 文字列リテラルのスタイルをシングルクォートに強制
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 
+# Rails/I18nLocaleTexts: I18nロケールテキストのスタイルチェックを無効にする
 Rails/I18nLocaleTexts:
   Enabled: false
+
+# RSpec関連の設定
+RSpec/AnyInstance:
+  Enabled: false  # allow_any_instance_ofの使用を禁止します。テストの可読性を向上させるために推奨されます。
+
+RSpec/ContextWording:
+  Enabled: false  # contextブロックの説明文が適切であるかをチェックしません。自由に記述できます。
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false  # 1つのテストで複数のletまたはlet!を使用することを許可します。柔軟性を持たせます。
+
+RSpec/MultipleExpectations:
+  Enabled: false  # 1つのテスト内で複数のexpectを使用することを許可します。テストの複雑さを増す可能性がありますが、便利です。
+
+Lint/MissingSuper:
+  Exclude:
+    - 'app/components/**/*'  # オーバーライドされたメソッドでsuperを呼び出さない場合に警告を出しますが、特定のディレクトリは除外します。
+
+RSpec/ExampleLength:
+  Enabled: false  # テストの例（itブロック）の長さを制限しません。長いテストも許可されます。
+
+RSpec/NestedGroups:
+  Enabled: false  # ネストされたdescribeやcontextグループの使用を許可します。テストの構造を柔軟にします。
+
+RSpec/LetSetup:
+  Enabled: false  # letを使用する際のセットアップが適切であるかをチェックしません。自由に使用できます。
+
+RSpec/NamedSubject:
+  Enabled: false  # subjectに名前を付けることを推奨しません。名前を付けなくても警告は表示されません。

--- a/spec/decorators/question_decorator_spec.rb
+++ b/spec/decorators/question_decorator_spec.rb
@@ -28,19 +28,17 @@ RSpec.describe QuestionDecorator do
   end
 
   describe '#implementation_year' do
-    let(:test){ create(:test, year:2023) }
+    let(:test) { create(:test, year: 2023) }
 
     it '回次と実施年度を返す' do
       expect(test.decorate.implementation_year).to eq '第58回(2023年度)'
     end
   end
-  
-  
 
   describe '#question_code_without_turn' do
-    let(:test){ create(:test, year:2023) }
-    let(:test_session){ create(:test_session, session: 'AM', test: ) }
-    let(:question){ create(:question, question_number: 100, test_session:)}
+    let(:test) { create(:test, year: 2023) }
+    let(:test_session) { create(:test_session, session: 'AM', test:) }
+    let(:question) { create(:question, question_number: 100, test_session:) }
 
     it 'セッション・問題番号を返す' do
       expect(test.decorate.question_code_without_turn(question)).to eq 'A100'

--- a/spec/decorators/tag_decorator_spec.rb
+++ b/spec/decorators/tag_decorator_spec.rb
@@ -3,8 +3,10 @@ require 'rails_helper'
 RSpec.describe TagDecorator do
   describe '#category_color' do
     subject { tag.decorate.category_color }
+
     context 'major_categoryの場合' do
       let(:tag) { create(:tag, :major_category) }
+
       it 'bg-amber-100を返す' do
         expect(subject).to eq('bg-amber-100')
       end
@@ -12,6 +14,7 @@ RSpec.describe TagDecorator do
 
     context 'special_tagsの場合' do
       let(:tag) { create(:tag, :special_tags) }
+
       it 'bg-blue-100を返す' do
         expect(subject).to eq('bg-blue-100')
       end
@@ -19,6 +22,7 @@ RSpec.describe TagDecorator do
 
     context 'common_tagsの場合' do
       let(:tag) { create(:tag, :common_tags) }
+
       it 'bg-green-100を返す' do
         expect(subject).to eq('bg-green-100')
       end

--- a/spec/decorators/test_decorator_spec.rb
+++ b/spec/decorators/test_decorator_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe TestDecorator do
   describe '#turn' do
-    let(:test){ create(:test, year:2023) }
+    let(:test) { create(:test, year: 2023) }
 
     it '回次を返す' do
       expect(test.decorate.turn).to eq 58
@@ -10,7 +10,7 @@ RSpec.describe TestDecorator do
   end
 
   describe '#implementation_year' do
-    let(:test){ create(:test, year:2023) }
+    let(:test) { create(:test, year: 2023) }
 
     it '回次と実施年度を返す' do
       expect(test.decorate.implementation_year).to eq '第58回(2023年度)'
@@ -18,9 +18,9 @@ RSpec.describe TestDecorator do
   end
 
   describe '#question_code_without_turn' do
-    let(:test){ create(:test, year:2023) }
-    let(:test_session){ create(:test_session, session: 'AM', test: ) }
-    let(:question){ create(:question, question_number: 100, test_session:)}
+    let(:test) { create(:test, year: 2023) }
+    let(:test_session) { create(:test_session, session: 'AM', test:) }
+    let(:question) { create(:question, question_number: 100, test_session:) }
 
     it 'セッション・問題番号を返す' do
       expect(test.decorate.question_code_without_turn(question)).to eq 'A100'

--- a/spec/factories/choices.rb
+++ b/spec/factories/choices.rb
@@ -20,9 +20,9 @@
 #
 FactoryBot.define do
   factory :choice do
-    association :question
+    question
     content { Faker::Lorem.sentence(word_count: 1) }
-    is_correct { Faker::Boolean.boolean }  # ランダムなtrue/falseを生成
+    is_correct { Faker::Boolean.boolean } # ランダムなtrue/falseを生成
     option_number { rand(1..5) }
   end
 end

--- a/spec/factories/examinations.rb
+++ b/spec/factories/examinations.rb
@@ -21,8 +21,8 @@
 #
 FactoryBot.define do
   factory :examination do
-    user { create(:user) }
-    test { create(:test) }
+    user { association :user }
+    test { association :test }
     attempt_date { Time.zone.now }
   end
 end

--- a/spec/factories/questions.rb
+++ b/spec/factories/questions.rb
@@ -20,7 +20,7 @@
 #
 FactoryBot.define do
   factory :question do
-    association :test_session
+    test_session
     question_number { rand(1..100) }
     content { Faker::Lorem.sentence(word_count: 3) }
   end

--- a/spec/factories/test_sessions.rb
+++ b/spec/factories/test_sessions.rb
@@ -18,8 +18,8 @@
 #
 FactoryBot.define do
   factory :test_session do
-    association :test
-    session { %w[AM PM].sample }  # AMまたはPMをランダムに選択
+    test
+    session { %w[AM PM].sample } # AMまたはPMをランダムに選択
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
   end

--- a/spec/factories/user_responses.rb
+++ b/spec/factories/user_responses.rb
@@ -20,11 +20,12 @@
 #
 FactoryBot.define do
   factory :user_response do
-    association :examination
-    association :choice
+    examination
+    choice
 
     after(:build) do |user_response|
-      user_response.choice ||= create(:choice, question: create(:question, test_session: user_response.examination.test_session))
+      user_response.choice ||= create(:choice,
+                                      question: create(:question, test_session: user_response.examination.test_session))
     end
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe ApplicationHelper, type: :helper do
+RSpec.describe ApplicationHelper do
   describe '#question_code' do
-    let(:test){ create(:test, year:2023) }
-    let(:test_session){ create(:test_session, session: 'AM', test: ) }
-    let(:question){ create(:question, question_number: 100, test_session:)}
+    let(:test) { create(:test, year: 2023) }
+    let(:test_session) { create(:test_session, session: 'AM', test:) }
+    let(:question) { create(:question, question_number: 100, test_session:) }
 
     it '簡略化された回次・セッション・問題番号を返す' do
       expect(question_code(question)).to eq '58A100'

--- a/spec/models/examination_spec.rb
+++ b/spec/models/examination_spec.rb
@@ -21,14 +21,14 @@
 #
 require 'rails_helper'
 
-RSpec.describe Examination, type: :model do
+RSpec.describe Examination do
   describe '.create_result!' do
     let(:user) { create(:user) }
     let(:test) { create(:test) }
     let(:choice_ids) { create_list(:choice, 3).map(&:id) }
-    let(:score_calculator_mock) { instance_double("Score::ScoreCalculator") }
+    let(:score_calculator_mock) { instance_double(Score::ScoreCalculator) }
     let(:params) do
-      { user_id: user.id, test_id: test.id, attempt_date: DateTime.current, choice_ids: choice_ids }
+      { user_id: user.id, test_id: test.id, attempt_date: DateTime.current, choice_ids: }
     end
 
     before do
@@ -40,9 +40,9 @@ RSpec.describe Examination, type: :model do
 
     it 'Examinationが作成され、UserResponseとScoreの処理が呼び出される' do
       # 参考：https://zenn.dev/igaiga/books/rails-practice-note/viewer/ruby_argument_literals#:~:text=%E5%BC%95%E6%95%B0%E3%82%92%E6%B8%A1%E3%81%99%E3%81%A8%E3%81%8D%E3%81%AB%E3%80%81%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5%E3%81%AE%E5%89%8D%E3%81%AB%20**%20%E3%82%92%E3%81%A4%E3%81%91%E3%81%A6%E6%B8%A1%E3%81%99%E3%81%A8%E3%80%81%E3%83%8F%E3%83%83%E3%82%B7%E3%83%A5%E3%81%AE%E5%90%84%E8%A6%81%E7%B4%A0%E3%82%92%E3%82%AD%E3%83%BC%E3%83%AF%E3%83%BC%E3%83%89%E5%BC%95%E6%95%B0%E3%81%A8%E3%81%97%E3%81%A6%E6%B8%A1%E3%81%99%E3%81%93%E3%81%A8%E3%81%8C%E3%81%A7%E3%81%8D%E3%81%BE%E3%81%99
-      expect { Examination.create_result!(**params) }.to change(Examination, :count).by(1)
-      expect(UserResponse).to have_received(:bulk_create_responses).with(instance_of(Examination), choice_ids)
+      expect { described_class.create_result!(**params) }.to change(described_class, :count).by(1)
+      expect(UserResponse).to have_received(:bulk_create_responses).with(instance_of(described_class), choice_ids)
       expect(score_calculator_mock).to have_received(:call)
     end
-  end 
+  end
 end

--- a/spec/models/pass_mark_spec.rb
+++ b/spec/models/pass_mark_spec.rb
@@ -20,6 +20,6 @@
 #
 require 'rails_helper'
 
-RSpec.describe PassMark, type: :model do
+RSpec.describe PassMark do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -20,12 +20,12 @@
 #
 require 'rails_helper'
 
-RSpec.describe Question, type: :model do
+RSpec.describe Question do
   let(:question) { create(:question) }
 
   describe '#correct_option_numbers' do
-    let!(:correct_choice){ create(:choice, question: , is_correct: true) }
-    let!(:incorrect_choice){ create(:choice, question: , is_correct: false) }
+    let!(:correct_choice) { create(:choice, question:, is_correct: true) }
+    let!(:incorrect_choice) { create(:choice, question:, is_correct: false) }
 
     it '正解の選択肢のみ配列で返される' do
       expect(question.correct_option_numbers).to eq([correct_choice.option_number])
@@ -36,20 +36,21 @@ RSpec.describe Question, type: :model do
     let(:examination) { create(:examination) }
 
     context 'questionに紐づくユーザーの回答がある場合' do
-      let(:first_choice) { create(:choice, question: ) }
-      let(:second_choice) { create(:choice, question: ) }
-      let!(:user_response1) { create(:user_response, examination: , choice: first_choice) }
-      let!(:user_response2) { create(:user_response, examination: , choice: second_choice) }
+      let(:first_choice) { create(:choice, question:) }
+      let(:second_choice) { create(:choice, question:) }
+      let!(:first_user_response) { create(:user_response, examination:, choice: first_choice) }
+      let!(:second_user_response) { create(:user_response, examination:, choice: second_choice) }
 
       it '回答（option_number）が配列で返される' do
-        expect(question.selected_option_numbers(examination)).to eq([first_choice.option_number, second_choice.option_number])
+        expect(question.selected_option_numbers(examination)).to eq([first_choice.option_number,
+                                                                     second_choice.option_number])
       end
     end
-  
+
     context 'questionに紐づく回答がない場合' do
-      let(:other_question){ create(:question) }
+      let(:other_question) { create(:question) }
       let(:other_choice) { create(:choice, question: other_question) }
-      let(:other_response){ create(:user_response, examination:, choice: other_choice) }
+      let(:other_response) { create(:user_response, examination:, choice: other_choice) }
 
       it '空の配列が返される' do
         expect(other_question.selected_option_numbers(examination)).to eq([])

--- a/spec/models/question_tag_spec.rb
+++ b/spec/models/question_tag_spec.rb
@@ -21,6 +21,6 @@
 #
 require 'rails_helper'
 
-RSpec.describe QuestionTag, type: :model do
+RSpec.describe QuestionTag do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/score_spec.rb
+++ b/spec/models/score_spec.rb
@@ -20,18 +20,19 @@
 #
 require 'rails_helper'
 
-RSpec.describe Score, type: :model do
+RSpec.describe Score do
   describe Score::ScoreCalculator, type: :class do
     let(:test) { create(:test) }
     let(:test_session) { create(:test_session, test:) }
     let(:examination) { create(:examination, test:) }
     let(:score) { create(:score, examination:) }
-    let(:score_calculator) { Score::ScoreCalculator.new(examination) }
+    let(:score_calculator) { described_class.new(examination) }
 
     describe '#practical_score' do
-      let(:practical_question) { create(:question, test_session: , question_number: (1..20).to_a.sample) }
-      let(:choice){ create(:choice, question: practical_question, is_correct: true) }
+      let(:practical_question) { create(:question, test_session:, question_number: (1..20).to_a.sample) }
+      let(:choice) { create(:choice, question: practical_question, is_correct: true) }
       let!(:user_responses) { create_list(:user_response, 10, examination:, choice:) }
+
       before do
         score_calculator.correct_responses
       end
@@ -42,9 +43,10 @@ RSpec.describe Score, type: :model do
     end
 
     describe '#common_score' do
-      let(:common_question) { create(:question, test_session: , question_number: (21..100).to_a.sample) }
-      let(:choice){ create(:choice, question: common_question, is_correct: true) }
+      let(:common_question) { create(:question, test_session:, question_number: (21..100).to_a.sample) }
+      let(:choice) { create(:choice, question: common_question, is_correct: true) }
       let!(:user_responses) { create_list(:user_response, 10, examination:, choice:) }
+
       before do
         score_calculator.correct_responses
       end
@@ -55,13 +57,13 @@ RSpec.describe Score, type: :model do
     end
 
     describe '#total_score' do
-      let(:common_question) { create(:question, test_session: , question_number: (21..100).to_a.sample) }
-      let(:practical_question) { create(:question, test_session: , question_number: (1..20).to_a.sample) }
-      let(:practical_choice){ create(:choice, question: practical_question, is_correct: true) }
-      let(:common_choice){ create(:choice, question: common_question, is_correct: true) }
-      let!(:common_responses) { create_list(:user_response, 10, examination: examination, choice: common_choice) }
-      let!(:practical_responses) { create_list(:user_response, 10, examination: examination, choice: practical_choice) }
-      
+      let(:common_question) { create(:question, test_session:, question_number: (21..100).to_a.sample) }
+      let(:practical_question) { create(:question, test_session:, question_number: (1..20).to_a.sample) }
+      let(:practical_choice) { create(:choice, question: practical_question, is_correct: true) }
+      let(:common_choice) { create(:choice, question: common_question, is_correct: true) }
+      let!(:common_responses) { create_list(:user_response, 10, examination:, choice: common_choice) }
+      let!(:practical_responses) { create_list(:user_response, 10, examination:, choice: practical_choice) }
+
       before do
         score_calculator.correct_responses
         score_calculator.practical_score
@@ -74,17 +76,17 @@ RSpec.describe Score, type: :model do
     end
 
     describe '#call' do
-      let(:common_question) { create(:question, test_session: , question_number: (21..100).to_a.sample) }
-      let(:practical_question) { create(:question, test_session: , question_number: (1..20).to_a.sample) }
-      let(:practical_choice){ create(:choice, question: practical_question, is_correct: true) }
-      let(:common_choice){ create(:choice, question: common_question, is_correct: true) }
-      let!(:common_responses) { create_list(:user_response, 20, examination: examination, choice: common_choice) }
-      let!(:practical_responses) { create_list(:user_response, 10, examination: examination, choice: practical_choice) }
+      let(:common_question) { create(:question, test_session:, question_number: (21..100).to_a.sample) }
+      let(:practical_question) { create(:question, test_session:, question_number: (1..20).to_a.sample) }
+      let(:practical_choice) { create(:choice, question: practical_question, is_correct: true) }
+      let(:common_choice) { create(:choice, question: common_question, is_correct: true) }
+      let!(:common_responses) { create_list(:user_response, 20, examination:, choice: common_choice) } # rubocop:disable FactoryBot/ExcessiveCreateList
+      let!(:practical_responses) { create_list(:user_response, 10, examination:, choice: practical_choice) }
 
       before do
         score_calculator.correct_responses
       end
-      
+
       it 'scoreが1件作成される' do
         expect { score_calculator.call }.to change(Score, :count).by(1)
       end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -13,6 +13,6 @@
 #
 require 'rails_helper'
 
-RSpec.describe Tag, type: :model do
+RSpec.describe Tag do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/test_session_spec.rb
+++ b/spec/models/test_session_spec.rb
@@ -18,6 +18,6 @@
 #
 require 'rails_helper'
 
-RSpec.describe TestSession, type: :model do
+RSpec.describe TestSession do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/test_spec.rb
+++ b/spec/models/test_spec.rb
@@ -9,6 +9,6 @@
 #
 require 'rails_helper'
 
-RSpec.describe Test, type: :model do
+RSpec.describe Test do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/user_response_spec.rb
+++ b/spec/models/user_response_spec.rb
@@ -20,23 +20,27 @@
 #
 require 'rails_helper'
 
-RSpec.describe UserResponse, type: :model do
+RSpec.describe UserResponse do
   describe '#bulk_create_responses' do
     let(:examination) { create(:examination) }
     let(:choice_ids) { create_list(:choice, 3).map(&:id) }
 
+    before do
+      allow(Rails.logger).to receive(:error)
+    end
+
     context '不正なchoice_idが含まれない場合' do
       it 'user_responsesが作成される' do
-        expect {
-          UserResponse.bulk_create_responses(examination, choice_ids)
-        }.to change(UserResponse, :count).by(3)
+        expect do
+          described_class.bulk_create_responses(examination, choice_ids)
+        end.to change(described_class, :count).by(3)
       end
 
       it 'choice_id毎にuser_responseが作成される' do
-        UserResponse.bulk_create_responses(examination, choice_ids)
+        described_class.bulk_create_responses(examination, choice_ids)
 
         choice_ids.each do |choice_id|
-          user_response = UserResponse.find_by(choice_id: choice_id)
+          user_response = described_class.find_by(choice_id:)
           expect(user_response.examination_id).to eq(examination.id)
           expect(user_response.choice_id).to eq(choice_id)
         end
@@ -49,17 +53,17 @@ RSpec.describe UserResponse, type: :model do
       it 'user_responseは1件も作成されない' do
         choice_ids_with_invalid = choice_ids + [invalid_choice_id]
 
-        expect {
-          UserResponse.bulk_create_responses(examination, choice_ids_with_invalid)
-        }.not_to change(UserResponse, :count)
+        expect do
+          described_class.bulk_create_responses(examination, choice_ids_with_invalid)
+        end.not_to change(described_class, :count)
       end
 
       it 'logにerror messageが含まれる' do
         choice_ids_with_invalid = choice_ids + [invalid_choice_id]
         missing_ids = [invalid_choice_id]
 
-        expect(Rails.logger).to receive(:error).with("Missing Choice IDs: #{missing_ids.join(', ')}").once
-        UserResponse.bulk_create_responses(examination.id, choice_ids_with_invalid)
+        described_class.bulk_create_responses(examination.id, choice_ids_with_invalid)
+        expect(Rails.logger).to have_received(:error).with("Missing Choice IDs: #{missing_ids.join(', ')}").once
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,10 +25,11 @@
 #
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
+RSpec.describe User do
   describe '正常系' do
     it 'ユーザー登録ができる' do
-      user = User.new(username: 'newuser', email: 'newuser@example.com', password: 'password', password_confirmation: 'password')
+      user = described_class.new(username: 'newuser', email: 'newuser@example.com', password: 'password',
+                                 password_confirmation: 'password')
       expect(user).to be_valid
     end
   end
@@ -36,34 +37,39 @@ RSpec.describe User, type: :model do
   describe '異常系' do
     context 'usernameが空の場合' do
       it 'ユーザー登録ができない' do
-        user = User.new(username: '', email: 'newuser@example.com', password: 'password', password_confirmation: 'password')
-        expect(user).to be_invalid
+        user = described_class.new(username: '', email: 'newuser@example.com', password: 'password',
+                                   password_confirmation: 'password')
+        expect(user).not_to be_valid
       end
     end
 
     context 'email関連' do
       it 'emailが空の場合ユーザー登録ができない' do
-        user = User.new(username: 'newuser', email: '', password: 'password', password_confirmation: 'password')
-        expect(user).to be_invalid
+        user = described_class.new(username: 'newuser', email: '', password: 'password',
+                                   password_confirmation: 'password')
+        expect(user).not_to be_valid
       end
 
       it 'emailが重複している場合ユーザー登録ができない' do
-        user1 = User.create(username: 'newuser1', email: 'newuser@example.com', password: 'password', password_confirmation: 'password')
-        user2 = User.new(username: 'newuser2', email: 'newuser@example.com', password: 'password', password_confirmation: 'password')
-        expect(user2).to be_invalid
+        described_class.create(username: 'newuser1', email: 'newuser@example.com', password: 'password',
+                               password_confirmation: 'password')
+        user2 = described_class.new(username: 'newuser2', email: 'newuser@example.com', password: 'password',
+                                    password_confirmation: 'password')
+        expect(user2).not_to be_valid
       end
     end
 
-
     context 'passwordが空の場合' do
       it 'ユーザー登録ができない' do
-        user = User.new(username: 'newuser', email: 'newuser@example.com', password: '', password_confirmation: 'password')
-        expect(user).to be_invalid
+        user = described_class.new(username: 'newuser', email: 'newuser@example.com', password: '',
+                                   password_confirmation: 'password')
+        expect(user).not_to be_valid
       end
 
       it 'passwordが6文字未満の場合ユーザー登録ができない' do
-        user = User.new(username: 'newuser', email: 'newuser@example.com', password: '12345', password_confirmation: '12345')
-        expect(user).to be_invalid
+        user = described_class.new(username: 'newuser', email: 'newuser@example.com', password: '12345',
+                                   password_confirmation: '12345')
+        expect(user).not_to be_valid
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 require 'capybara/rspec'
@@ -37,7 +37,7 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
 
   # テスト環境全体でのホスト情報設定
-  config.before(:each) do
+  config.before do
     ActionMailer::Base.default_url_options[:host] = 'localhost:3000'
   end
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-RSpec.describe 'Accounts', type: :request do
-  let(:user) {create(:user)}
+RSpec.describe 'Accounts' do
+  let(:user) { create(:user) }
 
   before do
     sign_in user
   end
 
-  describe "GET /show" do
-    it "returns http success" do
+  describe 'GET /show' do
+    it 'returns http success' do
       get '/account'
       expect(response).to have_http_status(:success)
     end

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -1,19 +1,19 @@
 require 'rails_helper'
 
-RSpec.describe "Dashboards", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Dashboards' do
+  describe 'GET /index' do
     let(:user) { create(:user) }
-    let(:test){ create(:test)}
-    let!(:pass_mark) { create(:pass_mark, test: ) }
-    let!(:examination) { create(:examination, test: , user: ) }
-    let!(:score) { create(:score, examination: ) }
+    let(:test) { create(:test) }
+    let!(:pass_mark) { create(:pass_mark, test:) }
+    let!(:examination) { create(:examination, test:, user:) }
+    let!(:score) { create(:score, examination:) }
 
     before do
       sign_in user
     end
 
-    it "returns http success" do
-      get "/dashboard"
+    it 'returns http success' do
+      get '/dashboard'
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/examinations_spec.rb
+++ b/spec/requests/examinations_spec.rb
@@ -1,14 +1,14 @@
 require 'rails_helper'
 
-RSpec.describe "Examinations", type: :request do
-  describe "GET /examinations/:id" do
+RSpec.describe 'Examinations' do
+  describe 'GET /examinations/:id' do
     let(:user) { create(:user) }
-    let(:test){create(:test)}
+    let(:test) { create(:test) }
     let(:test_session) { create(:test_session, test:) }
     let(:examination) { create(:examination, test:, user:) }
-    let!(:pass_mark){ create(:pass_mark, test:)}
+    let!(:pass_mark) { create(:pass_mark, test:) }
     let!(:score) { create(:score, examination:) }
-    let!(:question){ create(:question, test_session:) }
+    let!(:question) { create(:question, test_session:) }
     let!(:choice) { create(:choice, question:) }
     let!(:user_response) { create(:user_response, examination:, choice:) }
 
@@ -16,9 +16,9 @@ RSpec.describe "Examinations", type: :request do
       sign_in user
     end
 
-    it "returns http success" do
+    it 'returns http success' do
       get examination_path(examination)
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/scores_spec.rb
+++ b/spec/requests/scores_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe "Scores", type: :request do
+RSpec.describe 'Scores' do
   pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/requests/tests/selections_spec.rb
+++ b/spec/requests/tests/selections_spec.rb
@@ -1,11 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Tests::Selections", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Tests::Selections' do
+  describe 'GET /index' do
     it 'returns http success' do
       get '/tests/select'
       expect(response).to have_http_status(:success)
     end
   end
-
 end

--- a/spec/requests/tests_spec.rb
+++ b/spec/requests/tests_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe "Tests", type: :request do
-  describe "GET /tests/:id" do
-    let(:test){create(:test)}
-    let(:test_session) {create(:test_session, test: test)}
-    let!(:question) {create(:question, test_session: test_session)}
+RSpec.describe 'Tests' do
+  describe 'GET /tests/:id' do
+    let(:test) { create(:test) }
+    let(:test_session) { create(:test_session, test:) }
+    let!(:question) { create(:question, test_session:) }
 
-    it "returns http success" do
+    it 'returns http success' do
       get test_path(test)
       expect(response).to have_http_status(:success)
     end

--- a/spec/requests/top_spec.rb
+++ b/spec/requests/top_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe "Tops", type: :request do
-  describe "GET /" do
-    it "returns http success" do
+RSpec.describe 'Tops' do
+  describe 'GET /' do
+    it 'returns http success' do
       get '/'
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/user_responses_spec.rb
+++ b/spec/requests/user_responses_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'UserResponses', type: :request do
+RSpec.describe 'UserResponses' do
   describe 'POST /create' do
     let(:user) { create(:user) }
     let(:test) { create(:test) }
@@ -24,7 +24,7 @@ RSpec.describe 'UserResponses', type: :request do
       end
 
       it 'user_responseが作成されリダイレクトされる' do
-        post user_responses_path, params: params
+        post(user_responses_path, params:)
         expect(response).to redirect_to(dashboard_path)
         expect(flash[:notice]).to eq '試験結果を保存しました'
       end
@@ -36,11 +36,10 @@ RSpec.describe 'UserResponses', type: :request do
       end
 
       it 'newテンプレートがレンダリングされ、エラーメッセージが表示される' do
-        post user_responses_path, params: params
+        post(user_responses_path, params:)
         expect(response).to redirect_to(test_path(params[:test_id]))
         expect(flash[:alert]).to eq '試験結果を保存できませんでした'
       end
     end
   end
 end
-

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Users::passwords' do
-  let(:user) {create(:user)}
+  let(:user) { create(:user) }
 
   describe 'GET /users/password/new' do
     it 'パスワードリセットリクエスト送信先入力用のformが表示される' do
@@ -37,8 +37,8 @@ RSpec.describe 'Users::passwords' do
         user: {
           reset_password_token:,
           password: 'new-password',
-          password_confirmation: 'new-password',
-        },
+          password_confirmation: 'new-password'
+        }
       }
     end
 

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Users::registrations' do
-  let(:user) {create(:user)}
+  let(:user) { create(:user) }
 
   describe 'GET /users/sign_up' do
     it 'ユーザー登録画面が表示される' do
@@ -11,14 +11,19 @@ RSpec.describe 'Users::registrations' do
   end
 
   describe 'POST /users/sign_up' do
-    let(:valid_user_params) { { user: { username: 'newuser', email: 'newuser@example.com', password: 'password', password_confirmation: 'password' } } }
-    let(:invalid_user_params) { { user: { username: '', email: 'user@example.com', password: 'password', password_confirmation: 'password' } } }
+    let(:valid_user_params) do
+      { user: { username: 'newuser', email: 'newuser@example.com', password: 'password',
+                password_confirmation: 'password' } }
+    end
+    let(:invalid_user_params) do
+      { user: { username: '', email: 'user@example.com', password: 'password', password_confirmation: 'password' } }
+    end
 
     context '正常系' do
       it 'ユーザー登録後ダッシュボード画面にリダイレクトされる' do
-        expect {
+        expect do
           post user_registration_path, params: valid_user_params
-        }.to change(User, :count).by(1)
+        end.to change(User, :count).by(1)
         expect(response).to redirect_to(dashboard_path)
         expect(response).to have_http_status(:see_other)
       end
@@ -26,9 +31,9 @@ RSpec.describe 'Users::registrations' do
 
     context '不正なパラメータの場合' do
       it 'ユーザー登録ができず新規登録画面にリダイレクトされる' do
-        expect {
+        expect do
           post user_registration_path, params: invalid_user_params
-        }.not_to change(User, :count)
+        end.not_to change(User, :count)
         expect(response).to render_template(:new)
         expect(response).to have_http_status(:unprocessable_entity)
       end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Users::sessions' do
   describe 'POST /users/sign_in' do
-    let(:user) { User.create(username: 'testuser', email: 'testuser@example.com', password: 'password', password_confirmation: 'password') }
+    let(:user) do
+      User.create(username: 'testuser', email: 'testuser@example.com', password: 'password',
+                  password_confirmation: 'password')
+    end
     let(:valid_login_params) { { user: { email: 'testuser@example.com', password: 'password' } } }
     let(:invalid_login_params) { { user: { email: 'testuser@example.com', password: '123456789' } } }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end


### PR DESCRIPTION
対応するissue
---
close #69

概要
---

rubocopで対象外になっていたspecディレクトリ以下を対象に変更。これで出たリントエラーを解消した。
rubocopのRspec関連の設定も追加し、既存の設定と合わせて簡単な内容をコメントしておいた。