### PR TITLE
mini_tests_controllerでFormオブジェクトを使用する

### DIFF
--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,10 +1,11 @@
 class MiniTestsController < ApplicationController
   def index
-    if params[:search].present? && params[:search][:tag_ids].blank?
-      redirect_to tests_select_path, alert: 'タグを選択してください'
-    else
-      @questions = MiniTestSearchForm.new(params[:search]).search
+    form = MiniTestSearchForm.new(params[:search])
+    if form.valid?
+      @questions = form.search
       @user_responses = []
+    else
+      redirect_to tests_select_path, alert: form.errors.full_messages.join(', ')
     end
   end
 end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,6 +1,6 @@
 class MiniTestsController < ApplicationController
   def index
-    form = MiniTestSearchForm.new(params)
+    form = MiniTestSearchForm.new(search_params)
     if form.valid?
       @questions = form.search
       @user_responses = []

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,11 +1,17 @@
 class MiniTestsController < ApplicationController
   def index
-    form = MiniTestSearchForm.new(params[:search])
+    form = MiniTestSearchForm.new(params)
     if form.valid?
       @questions = form.search
       @user_responses = []
     else
       redirect_to tests_select_path, alert: form.errors.full_messages.join(', ')
     end
+  end
+
+  private
+
+  def search_params
+    params.require(:search).permit(tag_ids: [], question_count: nil)
   end
 end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,7 +1,10 @@
 class MiniTestsController < ApplicationController
   def index
-    Rails.logger.debug(params.inspect)
-    @questions = MiniTestSearchForm.new(params[:search]).search
+    @questions = if params[:search][:tag_ids].present?
+                   MiniTestSearchForm.new(params[:search]).search
+                 else
+                   redirect_to tests_select_path, alert: 'タグを選択してください'
+                 end
 
     @user_responses = []
   end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,11 +1,10 @@
 class MiniTestsController < ApplicationController
   def index
-    @questions = if params[:search][:tag_ids].present?
-                   MiniTestSearchForm.new(params[:search]).search
-                 else
-                   redirect_to tests_select_path, alert: 'タグを選択してください'
-                 end
-
-    @user_responses = []
+    if params[:search].present? && params[:search][:tag_ids].blank?
+      redirect_to tests_select_path, alert: 'タグを選択してください'
+    else
+      @questions = MiniTestSearchForm.new(params[:search]).search
+      @user_responses = []
+    end
   end
 end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,15 +1,6 @@
 class MiniTestsController < ApplicationController
   def index
-    # TODO: Formオブジェクト化する
-    tag_ids = params[:tag_ids] || []
-    # タグに基づいて質問のIDリストを配列で取得
-    question_ids = Question.joins(:question_tags)
-                           .where(question_tags: { tag_id: tag_ids })
-                           .distinct
-                           .pluck(:id)
-    # ランダムに選択する問題数を指定
-    question_count = params[:question_count].to_i
-    @questions = Question.random_questions(question_ids, question_count)
+    @questions = MiniTestSearchForm.new(params).search
 
     @user_responses = []
   end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,6 +1,7 @@
 class MiniTestsController < ApplicationController
   def index
-    @questions = MiniTestSearchForm.new(params).search
+    Rails.logger.debug(params.inspect)
+    @questions = MiniTestSearchForm.new(params[:search]).search
 
     @user_responses = []
   end

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -2,24 +2,17 @@ class MiniTestSearchForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attr_accessor :tag_ids, :question_count
-
-  attribute :tag_ids, :integer
-  attribute :question_count, :integer
+  attribute :tag_ids, default: []
+  attribute :question_count, :integer, default: 10
 
   validates :tag_ids, presence: { message: 'タグを選択してください' }
   validates :question_count, presence: true
 
-  def initialize(params)
-    @tag_ids = params[:tag_ids] || []
-    @question_count = params[:question_count].to_i || 10
-  end
-
   def search
     question_ids = Question.joins(:question_tags)
-                           .where(question_tags: { tag_id: @tag_ids })
+                           .where(question_tags: { tag_id: tag_ids })
                            .distinct
                            .pluck(:id)
-    Question.random_questions(question_ids, @question_count)
+    Question.random_questions(question_ids, question_count)
   end
 end

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -7,7 +7,7 @@ class MiniTestSearchForm
   attribute :tag_ids, :integer
   attribute :question_count, :integer
 
-  validates :tag_ids, presence: true
+  validates :tag_ids, presence: { message: 'タグを選択してください' }
   validates :question_count, presence: true
 
   def initialize(params)

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -1,0 +1,25 @@
+class MiniTestSearchForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :tag_ids, :question_count
+
+  attribute :tag_ids, :integer
+  attribute :question_count, :integer
+
+  validates :tag_ids, presence: true
+  validates :question_count, presence: true
+
+  def initialize(params)
+    @tag_ids = params[:tag_ids] || []
+    @question_count = params[:question_count].to_i
+  end
+
+  def search
+    question_ids = Question.joins(:question_tags)
+                           .where(question_tags: { tag_id: @tag_ids })
+                           .distinct
+                           .pluck(:id)
+    Question.random_questions(question_ids, @question_count)
+  end
+end

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -12,7 +12,7 @@ class MiniTestSearchForm
 
   def initialize(params)
     @tag_ids = params[:tag_ids] || []
-    @question_count = params[:question_count].to_i
+    @question_count = params[:question_count].to_i || 10
   end
 
   def search

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -39,15 +39,15 @@
               <h3 class='font-bold text-gray-900'>問題数を選択</h3>
               <div class='flex flex-wrap justify-start'>
                 <div class='mr-4'>
-                  <%= radio_button_tag 'question_count', 10, false, id: 'question_count_10' %>
+                  <%= radio_button_tag 'search[question_count]', 10, false, id: 'question_count_10' %>
                   <%= label_tag 'question_count_10', '10問' %>
                 </div>
                 <div class='mr-4'>
-                  <%= radio_button_tag 'question_count', 20, false, id: 'question_count_20' %>
+                  <%= radio_button_tag 'search[question_count]', 20, false, id: 'question_count_20' %>
                   <%= label_tag 'question_count_20', '20問' %>
                 </div>
                 <div class='mr-4'>
-                  <%= radio_button_tag 'question_count', 30, false, id: 'question_count_30' %>
+                  <%= radio_button_tag 'search[question_count]', 30, false, id: 'question_count_30' %>
                   <%= label_tag 'question_count_30', '30問' %>
                 </div>
               </div>
@@ -56,7 +56,7 @@
               <div class='flex flex-wrap justify-start'>
                 <% @major_categories.each do |tag| %>
                   <div class='mt-3 mr-2 bg-amber-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
-                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= check_box_tag 'search[tag_ids][]', tag.id, false, id: "tag_#{tag.id}" %>
                     <%= label_tag "tag_#{tag.id}", tag.name %>
                   </div>
                 <% end %>
@@ -65,7 +65,7 @@
               <div class='flex flex-wrap justify-start'>
                 <% @common_tags.each do |tag| %>
                   <div class='mt-3 mr-2 bg-green-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
-                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= check_box_tag 'search[tag_ids][]', tag.id, false, id: "tag_#{tag.id}" %>
                     <%= label_tag "tag_#{tag.id}", tag.name %>
                   </div>
                 <% end %>
@@ -74,7 +74,7 @@
               <div class='flex flex-wrap justify-start'>
                 <% @special_tags.each do |tag| %>
                   <div class='mt-3 mr-2 bg-blue-100 text-gray-800 font-bold py-2 px-4 shadow-xl text-center'>
-                    <%= check_box_tag 'tag_ids[]', tag.id, false, id: "tag_#{tag.id}" %>
+                    <%= check_box_tag 'search[tag_ids][]', tag.id, false, id: "tag_#{tag.id}" %>
                     <%= label_tag "tag_#{tag.id}", tag.name %>
                   </div>
                 <% end %>

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -39,7 +39,7 @@
               <h3 class='font-bold text-gray-900'>問題数を選択</h3>
               <div class='flex flex-wrap justify-start'>
                 <div class='mr-4'>
-                  <%= radio_button_tag 'search[question_count]', 10, false, id: 'question_count_10' %>
+                  <%= radio_button_tag 'search[question_count]', 10, true, id: 'question_count_10' %>
                   <%= label_tag 'question_count_10', '10問' %>
                 </div>
                 <div class='mr-4'>

--- a/spec/forms/mini_test_search_form_spec.rb
+++ b/spec/forms/mini_test_search_form_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe MiniTestSearchForm do
     {
       search: {
         tag_ids: [tag.id],
-        question_count: 10
+        question_count: 5 # 本来は10が最低だが絞り込みテストの件数を削減するために5に設定
       }
     }
   end
@@ -15,7 +15,7 @@ RSpec.describe MiniTestSearchForm do
   describe '#new' do
     it 'params[:search]を受け取りインスタンスが生成される' do
       expect(form.tag_ids).to eq([tag.id])
-      expect(form.question_count).to eq(10)
+      expect(form.question_count).to eq(5)
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe MiniTestSearchForm do
 
     it 'question_countをもとに取得する質問数を制限する' do
       questions = form.search
-      expect(questions.count).to eq(10)
+      expect(questions.count).to eq(5)
     end
   end
 end

--- a/spec/forms/mini_test_search_form_spec.rb
+++ b/spec/forms/mini_test_search_form_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe MiniTestSearchForm do
+  let(:tag) { create(:tag) }
+  let(:params) do
+    {
+      search: {
+        tag_ids: [tag.id],
+        question_count: 10
+      }
+    }
+  end
+  let!(:form) { described_class.new(params[:search]) }
+
+  describe '#new' do
+    it 'params[:search]を受け取りインスタンスが生成される' do
+      expect(form.tag_ids).to eq([tag.id])
+      expect(form.question_count).to eq(10)
+    end
+  end
+
+  describe '#search' do
+    let!(:question_tags) { create_list(:question_tag, 10, tag:) }
+
+    it 'tag_idsをもとにQuestionを取得する' do
+      questions = form.search
+      questions.each do |q|
+        expect(q.question_tags.pluck(:tag_id)).to include(tag.id)
+      end
+    end
+
+    it 'question_countをもとに取得する質問数を制限する' do
+      questions = form.search
+      expect(questions.count).to eq(10)
+    end
+  end
+end

--- a/spec/requests/mini_tests_spec.rb
+++ b/spec/requests/mini_tests_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'MiniTests' do
     end
 
     context 'タグを指定していない場合' do
-      let!(:params) do
+      let(:params) do
         {
           search: {
             tag_ids: nil,

--- a/spec/requests/mini_tests_spec.rb
+++ b/spec/requests/mini_tests_spec.rb
@@ -7,18 +7,37 @@ RSpec.describe 'MiniTests' do
     let(:tag) { create(:tag) }
     let!(:question) { create(:question, test_session:) }
     let!(:question_tag) { create(:question_tag, question:, tag:) }
-    let(:params) do
-      {
-        search: {
-          tag_ids: [tag.id],
-          question_count: 10
+
+    context 'タグを指定している場合' do
+      let(:params) do
+        {
+          search: {
+            tag_ids: [tag.id],
+            question_count: 10
+          }
         }
-      }
+      end
+
+      it 'returns http success' do
+        get('/mini_tests', params:)
+        expect(response).to have_http_status(:success)
+      end
     end
 
-    it 'returns http success' do
-      get('/mini_tests', params:)
-      expect(response).to have_http_status(:success)
+    context 'タグを指定していない場合' do
+      let!(:params) do
+        {
+          search: {
+            tag_ids: nil,
+            question_count: 10
+          }
+        }
+      end
+
+      it 'test/selectにリダイレクトする' do
+        get('/mini_tests', params:)
+        expect(response).to redirect_to(tests_select_path)
+      end
     end
   end
 end

--- a/spec/requests/mini_tests_spec.rb
+++ b/spec/requests/mini_tests_spec.rb
@@ -7,9 +7,17 @@ RSpec.describe 'MiniTests' do
     let(:tag) { create(:tag) }
     let!(:question) { create(:question, test_session:) }
     let!(:question_tag) { create(:question_tag, question:, tag:) }
+    let(:params) do
+      {
+        search: {
+          tag_ids: [tag.id],
+          question_count: 10
+        }
+      }
+    end
 
     it 'returns http success' do
-      get '/mini_tests', params: { search: { tag_ids: [tag.id], question_count: 1 } }
+      get('/mini_tests', params:)
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
対応するissue
---
close #68

概要
---

提示していただいた実装例をもとにFormオブジェクトを作成しました。


エンドポイント
---

変化ありません。


UI の比較
----

変化ありません



実装の詳細
----

- 提示していただいた例をもとに以下の点を修正しました
- `ActiveModel::Attributes`をincludeしていたので`tag_ids`と`question_count`のattributeを指定した
- `question_count`と`tag_ids`が空にならないようにした
- MiniTestSearchFormのテストを実装した

追加した Gem
---

- なし

備考
---

その他になにかあれば