### PR TITLE
ゲストログイン機能を実装

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -13,7 +13,7 @@ jobs:
         env:
           TZ: "Asia/Tokyo"
           MYSQL_ROOT_PASSWORD: password
-          options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
     container:
       image: ruby:3.3.1
       env:

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,9 +19,17 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   def guest_sign_in
-    user = User.guest
+    user = User.create_guest
     sign_in user
     redirect_to tests_select_path, notice: 'ゲストユーザーとしてログインしました。'
+  end
+
+  def guest_sign_out
+    return unless current_user.guest?
+
+    current_user.destroy
+    sign_out current_user
+    redirect_to root_path, notice: 'ゲストユーザーからログアウトしました。'
   end
 
   # protected

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -18,6 +18,12 @@ class Users::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def guest_sign_in
+    user = User.guest
+    sign_in user
+    redirect_to tests_select_path, notice: 'ゲストユーザーとしてログインしました。'
+  end
+
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,4 +33,11 @@ class User < ApplicationRecord
   validates :username, presence: true
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, length: { minimum: 6 }
+
+  def self.guest
+    find_or_create_by(email: 'guest@example.com') do |user|
+      user.username = 'ゲストユーザー'
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,13 +35,16 @@ class User < ApplicationRecord
   validates :password, presence: true, length: { minimum: 6 }
 
   def self.create_guest
-    find_or_create_by(email: 'guest@example.com') do |user|
+    unique_email = "guest_#{SecureRandom.hex(5)}@example.com"
+    create do |user|
+      user.email = unique_email
       user.username = 'ゲストユーザー'
       user.password = SecureRandom.urlsafe_base64
     end
   end
 
   def guest?
-    email == 'guest@example.com'
+    # ゲストユーザーのメールアドレスの型をチェック
+    email.start_with?('guest_') && email.end_with?('@example.com')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,10 +34,14 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, length: { minimum: 6 }
 
-  def self.guest
+  def self.create_guest
     find_or_create_by(email: 'guest@example.com') do |user|
       user.username = 'ゲストユーザー'
       user.password = SecureRandom.urlsafe_base64
     end
+  end
+
+  def guest?
+    email == 'guest@example.com'
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -9,7 +9,12 @@
         <%= link_to '過去問演習', tests_select_path, class: 'mr-5 hover:text-orange-300 block' %>
         <% if user_signed_in? %>
             <div class="mr-5 hover:text-orange-300">
-                <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete } %>
+                <% if current_user.guest? %>
+                    <%= button_to 'ゲストログアウト', users_guest_sign_out_path, method: :delete,
+                                                                         data: { turbo_method: :delete } %>
+                <% else %>
+                    <%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete } %>
+                <% end %>
             </div>
             <%= link_to 'マイページ', account_path, class: 'mr-5 hover:text-orange-300 block' %>
         <% else %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -14,6 +14,8 @@
             <%= link_to 'マイページ', account_path, class: 'mr-5 hover:text-orange-300 block' %>
         <% else %>
             <%= link_to 'ログイン', new_user_session_path, class: 'mr-5 hover:text-orange-300 block' %>
+            <%= link_to 'ゲストログイン', users_guest_sign_in_path, data: { 'turbo-method': :post },
+                                                             class: 'mr-5 hover:text-orange-300 block' %>
         <% end %>
     </nav>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
+    delete 'users/guest_sign_out', to: 'users/sessions#guest_sign_out'
   end
   
   root to: 'top#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
   require 'sidekiq/web'
-    devise_for :users, controllers: {
+  devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions',
     passwords: 'users/passwords'
   }
+
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#guest_sign_in'
+  end
   
   root to: 'top#index'
   get '/dashboard' => 'dashboard#index'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,4 +80,17 @@ RSpec.describe User do
       expect(user).to be_guest
     end
   end
+
+  describe '#guest?' do
+    it 'ゲストユーザーの場合はtrueを返す' do
+      user = described_class.create_guest
+      expect(user.guest?).to be true
+    end
+
+    it 'ゲストユーザーでない場合はfalseを返す' do
+      user = described_class.create(username: 'newuser', email: 'non_guest_user@example.com', password: 'password',
+                                    password_confirmation: 'password')
+      expect(user.guest?).to be false
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -73,4 +73,11 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#create_guest' do
+    it 'ゲストユーザーが作成できる' do
+      user = described_class.create_guest
+      expect(user).to be_guest
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,16 +82,26 @@ RSpec.describe User do
   end
 
   describe '#guest?' do
-    it 'ゲストユーザーの場合はtrueを返す' do
-      user = described_class.create(username: 'ゲストユーザー', email: 'guest_user@example.com', password: 'password',
-                                    password_confirmation: 'password')
-      expect(user.guest?).to be true
+    context 'アドレスが指定した型の場合' do
+      it 'trueを返す' do
+        user = described_class.create(username: 'newuser', email: 'guest_user_new@example.com', password: 'password',
+                                      password_confirmation: 'password')
+        expect(user.guest?).to be true
+      end
     end
 
-    it 'ゲストユーザーでない場合はfalseを返す' do
-      user = described_class.create(username: 'newuser', email: 'non_guest_user@example.com', password: 'password',
-                                    password_confirmation: 'password')
-      expect(user.guest?).to be false
+    context 'アドレスが指定した型でない場合' do
+      it 'guest_で始まらない場合はfalseを返す' do
+        user = described_class.create(username: 'newuser', email: 'non_guest_user@example.com', password: 'password',
+                                      password_confirmation: 'password')
+        expect(user.guest?).to be false
+      end
+
+      it '@example.comで終わらない場合はfalseを返す' do
+        user = described_class.create(username: 'newuser', email: 'guest_user@gmail.com', password: 'password',
+                                      password_confirmation: 'password')
+        expect(user.guest?).to be false
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,7 +83,8 @@ RSpec.describe User do
 
   describe '#guest?' do
     it 'ゲストユーザーの場合はtrueを返す' do
-      user = described_class.create_guest
+      user = described_class.create(username: 'ゲストユーザー', email: 'guest_user@example.com', password: 'password',
+                                    password_confirmation: 'password')
       expect(user.guest?).to be true
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,25 +82,27 @@ RSpec.describe User do
   end
 
   describe '#guest?' do
+    subject { user.guest? }
+
+    let(:user) { create(:user, email:) }
+
     context 'アドレスが指定した型の場合' do
-      it 'trueを返す' do
-        user = described_class.create(username: 'newuser', email: 'guest_user_new@example.com', password: 'password',
-                                      password_confirmation: 'password')
-        expect(user.guest?).to be true
-      end
+      let(:email) { 'guest_user_new@example.com' }
+
+      it { is_expected.to be true }
     end
 
     context 'アドレスが指定した型でない場合' do
-      it 'guest_で始まらない場合はfalseを返す' do
-        user = described_class.create(username: 'newuser', email: 'non_guest_user@example.com', password: 'password',
-                                      password_confirmation: 'password')
-        expect(user.guest?).to be false
+      context 'guest_で始まらない場合' do
+        let(:email) { 'non_guest_user@example.com' }
+
+        it { is_expected.to be false }
       end
 
-      it '@example.comで終わらない場合はfalseを返す' do
-        user = described_class.create(username: 'newuser', email: 'guest_user@gmail.com', password: 'password',
-                                      password_confirmation: 'password')
-        expect(user.guest?).to be false
+      context '@example.comで終わらない場合' do
+        let(:email) { 'guest_user@gmail.com' }
+
+        it { is_expected.to be false }
       end
     end
   end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -26,4 +26,26 @@ RSpec.describe 'Users::sessions' do
       end
     end
   end
+
+  describe 'POST /users/guest_sign_in' do
+    it 'ゲストユーザーとしてログインできる' do
+      post users_guest_sign_in_path
+      expect(response).to redirect_to(tests_select_path)
+      expect(response).to have_http_status(:found)
+    end
+  end
+
+  describe 'DELETE /users/guest_sign_out' do
+    let(:guest_user) { User.create_guest }
+
+    before do
+      sign_in guest_user
+    end
+
+    it 'ゲストユーザーからログアウトできる' do
+      delete users_guest_sign_out_path
+      expect(response).to redirect_to(root_path)
+      expect(response).to have_http_status(:found)
+    end
+  end
 end


### PR DESCRIPTION
対応するissue
---
Closes #76

概要
---

ゲストアカウントでのログイン・ログアウト機能を実装しました。
仕様として以下が望ましいと思いました。
- ログインの際にゲストアカウントとして作られる
- ログアウトの際にアカウントが削除される


エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `POST users/guest_sign_in`| `users/sessions#guest_sign_in` | ゲストログイン |
| `DELETE users/guest_sign_out`| `users/sessions#guest_sign_out` | ゲストログアウト |


UI の比較
----
### ヘッダー部分
<a href="https://gyazo.com/5c25482585d3542fc743887bf93c7f6a"><img src="https://i.gyazo.com/5c25482585d3542fc743887bf93c7f6a.png" alt="Image from Gyazo" width="576"/></a>

### 挙動
<a href="https://gyazo.com/f12e03f41cd40c7c218b9716bf42d9fd"><img src="https://i.gyazo.com/f12e03f41cd40c7c218b9716bf42d9fd.gif" alt="Image from Gyazo" width="900"/></a>

実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- ありません

備考
---

ゲストアカウントはそれぞれ独立させたい。共通のアカウントでは同時時刻にログイン・ログアウトすると複数のユーザーに影響がありそう。
使い捨てのアカウントを作成し、ゲスト判定する方針としました。Userテーブルに`is_guest`のようなフラグを持たせることも考えましたが現状の方がシンプるかと思いこの形にしました。ゲスト判定をする部分がシンプルじゃない気はしますが...