### PR TITLE
github actionsでdb:createでよくエラーが出るのでバージョンアップする

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -19,12 +19,12 @@ jobs:
       env:
         RAILS_ENV: test
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
         - name: bundler config
           run: bundle config set path 'vendor/bundle'
         - name: cache gems
           id: cache-gems
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: vendor/bundle
             key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -48,12 +48,12 @@ jobs:
     container:
       image: ruby:3.3.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: bundler config
         run: bundle config set path 'vendor/bundle'
       - name: Cache gems
         id: cache-gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
@@ -70,12 +70,12 @@ jobs:
     container:
       image: ruby:3.3.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: bundler config
         run: bundle config set path 'vendor/bundle'
       - name: Cache gems
         id: cache-gems
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}


### PR DESCRIPTION
概要
---

github actinosでrspecを実行する際に毎回のようにdb:createで失敗しrerunしている。エラーにv2をupdateしろと出るのでしてみた

