### PR TITLE
paramsからquestion_countを受け取れるように修正

### DIFF
--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,17 +1,11 @@
 class MiniTestsController < ApplicationController
   def index
-    form = MiniTestSearchForm.new(search_params)
+    form = MiniTestSearchForm.new(params)
     if form.valid?
       @questions = form.search
       @user_responses = []
     else
       redirect_to tests_select_path, alert: form.errors.full_messages.join(', ')
     end
-  end
-
-  private
-
-  def search_params
-    params.require(:search).permit(tag_ids: [], question_count: nil)
   end
 end

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -2,11 +2,15 @@ class MiniTestSearchForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :tag_ids, default: []
-  attribute :question_count, :integer, default: 10
+  attr_accessor :tag_ids, :question_count
 
   validates :tag_ids, presence: { message: 'タグを選択してください' }
   validates :question_count, presence: true
+
+  def initialize(params = {})
+    @tag_ids = params.dig(:search, :tag_ids) || []
+    @question_count = params.dig(:search, :question_count).to_i
+  end
 
   def search
     question_ids = Question.joins(:question_tags)

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,6 +1,5 @@
 <%= form_with url: user_responses_path, method: :post do |f| %>
-  <%# mini_testフラグを持たせる %>
-  <%# = hidden_field_tag :test_id, @test.id %>
+  <%= @questions.length %>
   <%= render 'tests/question', question: @questions %>
   <div class="text-center justify-center">
     <%= f.submit 'テストを終了する',

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,5 +1,4 @@
 <%= form_with url: user_responses_path, method: :post do |f| %>
-  <%= @questions.length %>
   <%= render 'tests/question', question: @questions %>
   <div class="text-center justify-center">
     <%= f.submit 'テストを終了する',

--- a/spec/forms/mini_test_search_form_spec.rb
+++ b/spec/forms/mini_test_search_form_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe MiniTestSearchForm do
       }
     }
   end
-  let!(:form) { described_class.new(params[:search]) }
+  let!(:form) { described_class.new(params) }
 
   describe '#new' do
     it 'params[:search]を受け取りインスタンスが生成される' do


### PR DESCRIPTION
概要
---

他のIssueに取り組んでいる際にquestion_countがデフォルトの10以外機能していないことがわかった。
原因としてparamsからquestion_countが受け取れていないため、毎回デフォルトが適応されていたよう。

コントローラではparams全てを受け取り、Formオブジェクト側ではinitializeするようにした