### PR TITLE
mini_testsの回答確認機能を実装

### DIFF
--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -10,9 +10,7 @@ class MiniTestsController < ApplicationController
   end
 
   def create
-    @selected_answers = Choice.where(id: params[:user_response][:choice_ids])
-                              .group_by(&:question_id)
-                              .transform_values { |choices| choices.map(&:option_number) }
+    @selected_answers = Choice.mini_test_answers(params[:user_response][:choice_ids])
     @questions = Question.where(id: params[:question_ids])
 
     respond_to do |format|

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -9,7 +9,7 @@ class MiniTestsController < ApplicationController
     end
   end
 
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @selected_answers = Choice.where(id: params[:user_response][:choice_ids])
                               .group_by(&:question_id)
                               .transform_values { |choices| choices.map(&:option_number) }
@@ -17,8 +17,10 @@ class MiniTestsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream do
-        render turbo_stream: turbo_stream.replace('mini_test_answers', partial: 'mini_tests/answers',
-                                                                       locals: { selected_answers: @selected_answers, questions: @questions })
+        render turbo_stream: turbo_stream.replace('mini_test_answers',
+                                                  partial: 'mini_tests/answers',
+                                                  locals: { selected_answers: @selected_answers,
+                                                            questions: @questions })
         format.html
       end
     end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -9,20 +9,14 @@ class MiniTestsController < ApplicationController
     end
   end
 
-  def create # rubocop:disable Metrics/MethodLength
+  def create
     @selected_answers = Choice.where(id: params[:user_response][:choice_ids])
                               .group_by(&:question_id)
                               .transform_values { |choices| choices.map(&:option_number) }
     @questions = Question.where(id: params[:question_ids])
 
     respond_to do |format|
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace('mini_test_answers',
-                                                  partial: 'mini_tests/answers',
-                                                  locals: { selected_answers: @selected_answers,
-                                                            questions: @questions })
-        format.html
-      end
+      format.turbo_stream
     end
   end
 end

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -8,4 +8,19 @@ class MiniTestsController < ApplicationController
       redirect_to tests_select_path, alert: form.errors.full_messages.join(', ')
     end
   end
+
+  def create
+    @selected_answers = Choice.where(id: params[:user_response][:choice_ids])
+                              .group_by(&:question_id)
+                              .transform_values { |choices| choices.map(&:option_number) }
+    @questions = Question.where(id: params[:question_ids])
+
+    respond_to do |format|
+      format.turbo_stream do
+        render turbo_stream: turbo_stream.replace('mini_test_answers', partial: 'mini_tests/answers',
+                                                                       locals: { selected_answers: @selected_answers, questions: @questions })
+        format.html
+      end
+    end
+  end
 end

--- a/app/helpers/mini_tests_helper.rb
+++ b/app/helpers/mini_tests_helper.rb
@@ -2,6 +2,6 @@ module MiniTestsHelper
   def correct_answer_icon(selected_answers, question)
     selected_answers = selected_answers[question.id]
     correct_answers = question.correct_option_numbers
-    selected_answers&.join(', ') == correct_answers.join(', ') ? '⭕️' : '❌'
+    selected_answers == correct_answers ? '⭕️' : '❌'
   end
 end

--- a/app/helpers/mini_tests_helper.rb
+++ b/app/helpers/mini_tests_helper.rb
@@ -1,0 +1,7 @@
+module MiniTestsHelper
+  def correct_answer_icon(selected_answers, question)
+    selected_answers = selected_answers[question.id]
+    correct_answers = question.correct_option_numbers
+    selected_answers&.join(', ') == correct_answers.join(', ') ? '⭕️' : '❌'
+  end
+end

--- a/app/models/choice.rb
+++ b/app/models/choice.rb
@@ -23,4 +23,8 @@ class Choice < ApplicationRecord
   has_many :user_responses, dependent: :destroy
 
   validates :option_number, presence: true, numericality: { in: 1..5 }
+
+  def self.mini_test_answers(choice_ids)
+    where(id: choice_ids).group_by(&:question_id).transform_values { |choices| choices.map(&:option_number) }
+  end
 end

--- a/app/views/mini_tests/_answers.html.erb
+++ b/app/views/mini_tests/_answers.html.erb
@@ -1,5 +1,5 @@
 <% if selected_answers.present? %>
-  <div class="flex justify-center items-center min-h-screen">
+  <div class="flex justify-center items-center mb-5">
     <div class="grid grid-cols-1 gap-2">
       <table class="table-auto w-full max-w-4xl text-center border-collapse">
         <% questions.each_slice(10) do |questions_slice| %>
@@ -30,9 +30,21 @@
                 </td>
               <% end %>
             </tr>
+            <tr>
+              <td class="border border-gray-300 px-2 py-1">正誤</td>
+              <% questions_slice.each do |question| %>
+                <td class="border border-gray-300 px-2 py-1 bg-green-100">
+                  <%= correct_answer_icon(selected_answers, question) %>
+                </td>
+              <% end %>
+            </tr>
           </tbody>
         <% end %>
       </table>
     </div>
+  </div>
+  <div class="text-center justify-center">
+    <%= link_to '問題選択画面に戻る', tests_select_path, class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
+                    font-bold py-2 px-4 rounded-lg shadow-xl' %>
   </div>
 <% end %>

--- a/app/views/mini_tests/_answers.html.erb
+++ b/app/views/mini_tests/_answers.html.erb
@@ -1,0 +1,38 @@
+<% if selected_answers.present? %>
+  <div class="flex justify-center items-center min-h-screen">
+    <div class="grid grid-cols-1 gap-2">
+      <table class="table-auto w-full max-w-4xl text-center border-collapse">
+        <% questions.each_slice(10) do |questions_slice| %>
+          <thead>
+            <tr>
+              <th class="border-b-2 border-gray-300 px-2 py-1">問題番号</th>
+              <% questions_slice.each do |question| %>
+                <th class="border-b-2 border-gray-300 px-2 py-1">
+                  <%= question_code(question) %>
+                </th>
+              <% end %>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="border border-gray-300 px-2 py-1">回答</td>
+              <% questions_slice.each do |question| %>
+                <td class="border border-gray-300 px-2 py-1 bg-sky-100">
+                  <%= selected_answers[question.id]&.join(', ') %>
+                </td>
+              <% end %>
+            </tr>
+            <tr>
+              <td class="border border-gray-300 px-2 py-1">正答</td>
+              <% questions_slice.each do |question| %>
+                <td class="border border-gray-300 px-2 py-1 bg-green-100">
+                  <%= question.correct_option_numbers.join(', ') %>
+                </td>
+              <% end %>
+            </tr>
+          </tbody>
+        <% end %>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/mini_tests/_answers.html.erb
+++ b/app/views/mini_tests/_answers.html.erb
@@ -43,8 +43,4 @@
       </table>
     </div>
   </div>
-  <div class="text-center justify-center">
-    <%= link_to '問題選択画面に戻る', tests_select_path, class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
-                    font-bold py-2 px-4 rounded-lg shadow-xl' %>
-  </div>
 <% end %>

--- a/app/views/mini_tests/create.turbo_stream.erb
+++ b/app/views/mini_tests/create.turbo_stream.erb
@@ -1,0 +1,10 @@
+<%= turbo_stream.replace "mini_test_answers" do %>
+  <%= render 'mini_tests/answers', selected_answers: @selected_answers, questions: @questions %>
+<% end %>
+
+<%= turbo_stream.replace "mini_test_submit" do %>
+  <div class="text-center justify-center">
+    <%= link_to '問題選択画面に戻る', tests_select_path, class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
+                    font-bold py-2 px-4 rounded-lg shadow-xl' %>
+  </div>
+<% end %>

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -3,13 +3,12 @@
     <%= hidden_field_tag 'question_ids[]', question.id %>
   <% end %>
   <%= render 'tests/question', question: @questions %>
-  <div class="text-center justify-center">
-    <%= f.submit 'テストを終了する',
-                 class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
-                    font-bold py-2 px-4 rounded-lg shadow-xl' %>
-  </div>
-<% end %>
-
-  <%= turbo_frame_tag 'mini_test_answers' do %>
+    <%= turbo_frame_tag 'mini_test_answers' do %>
     <%= render 'mini_tests/answers', selected_answers: @selected_answers, questions: @questions %>
+    <div class="text-center justify-center">
+      <%= f.submit 'テストを終了する',
+                   class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
+                      font-bold py-2 px-4 rounded-lg shadow-xl' %>
+    </div>
   <% end %>
+<% end %>

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: mini_tests_path, data: { controller: 'mini-test' } do |f| %>
+<%= form_with url: mini_tests_path do |f| %>
   <% @questions.each do |question| %>
     <%= hidden_field_tag 'question_ids[]', question.id %>
   <% end %>

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,14 +1,15 @@
-<%= form_with url: mini_tests_path, html: { data: { turbo_frame: 'mini_test_answers' } } do |f| %>
+<%= form_with url: mini_tests_path, data: { controller: 'mini-test' } do |f| %>
   <% @questions.each do |question| %>
     <%= hidden_field_tag 'question_ids[]', question.id %>
   <% end %>
   <%= render 'tests/question', question: @questions %>
-    <%= turbo_frame_tag 'mini_test_answers' do %>
-    <%= render 'mini_tests/answers', selected_answers: @selected_answers, questions: @questions %>
-    <div class="text-center justify-center">
-      <%= f.submit 'テストを終了する',
-                   class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
-                      font-bold py-2 px-4 rounded-lg shadow-xl' %>
-    </div>
-  <% end %>
+
+  <div id="mini_test_answers">
+  </div>
+
+  <div id="mini_test_submit" class="text-center justify-center">
+    <%= f.submit 'テストを終了する',
+                 class: 'bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
+                    font-bold py-2 px-4 rounded-lg shadow-xl' %>
+  </div>
 <% end %>

--- a/app/views/mini_tests/index.html.erb
+++ b/app/views/mini_tests/index.html.erb
@@ -1,4 +1,7 @@
-<%= form_with url: user_responses_path, method: :post do |f| %>
+<%= form_with url: mini_tests_path, html: { data: { turbo_frame: 'mini_test_answers' } } do |f| %>
+  <% @questions.each do |question| %>
+    <%= hidden_field_tag 'question_ids[]', question.id %>
+  <% end %>
   <%= render 'tests/question', question: @questions %>
   <div class="text-center justify-center">
     <%= f.submit 'テストを終了する',
@@ -6,3 +9,7 @@
                     font-bold py-2 px-4 rounded-lg shadow-xl' %>
   </div>
 <% end %>
+
+  <%= turbo_frame_tag 'mini_test_answers' do %>
+    <%= render 'mini_tests/answers', selected_answers: @selected_answers, questions: @questions %>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,7 +21,7 @@ Rails.application.routes.draw do
     get '/select' => 'selections#index'
   end
   get '/tests/:id' => 'tests#show', as: 'test'
-  get 'mini_tests' => 'mini_tests#index'
+  resources :mini_tests, only: [:index, :create]
 
   resources :examinations do
     resources :scores, only: [:show]

--- a/db/migrate/20241201115026_remove_unique_index_from_users.rb
+++ b/db/migrate/20241201115026_remove_unique_index_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveUniqueIndexFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :users, :username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_11_11_010832) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_01_115026) do
   create_table "choices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "question_id", null: false
     t.string "content", null: false
@@ -23,10 +23,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_11_010832) do
 
   create_table "examinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.bigint "test_id", null: false
+    t.bigint "test_id"
     t.datetime "attempt_date", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "mini_test"
     t.index ["test_id"], name: "index_examinations_on_test_id"
     t.index ["user_id"], name: "index_examinations_on_user_id"
   end
@@ -117,7 +118,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_11_11_010832) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
   add_foreign_key "choices", "questions"

--- a/spec/helpers/mini_tests_helper_spec.rb
+++ b/spec/helpers/mini_tests_helper_spec.rb
@@ -11,5 +11,25 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe MiniTestsHelper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#correct_answer_icon' do
+    subject { helper.correct_answer_icon(selected_answers, question) }
+
+    let(:question) { create(:question) }
+
+    context '正答の場合' do
+      let(:correct_choice) { create(:choice, question:, is_correct: true, option_number: 1) }
+      # コントローラでハッシュにしている
+      let(:selected_answers) { { question.id => [correct_choice.option_number] } }
+
+      it { is_expected.to eq('⭕️') }
+    end
+
+    context '誤答の場合' do
+      let(:incorrect_choice) { create(:choice, question:, is_correct: false, option_number: 2) }
+      # コントローラでハッシュにしている
+      let(:selected_answers) { { question.id => [incorrect_choice.option_number] } }
+
+      it { is_expected.to eq('❌') }
+    end
+  end
 end

--- a/spec/helpers/mini_tests_helper_spec.rb
+++ b/spec/helpers/mini_tests_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the MiniTestsHelper. For example:
+#
+# describe MiniTestsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe MiniTestsHelper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/choice_spec.rb
+++ b/spec/models/choice_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe Choice do
+  describe '.mini_test_answers' do
+    subject { described_class.mini_test_answers(choice_ids) }
+
+    let(:first_question) { create(:question) }
+    let(:second_question) { create(:question) }
+    let(:first_choice) { create(:choice, question: first_question) }
+    let(:second_choice) { create(:choice, question: second_question) }
+
+    context '有効な choice_ids が提供された場合' do
+      let!(:choice_ids) { [first_choice.id, second_choice.id] }
+
+      it '質問ごとに正しい選択肢の番号を返す' do
+        result = {
+          first_question.id => [first_choice.option_number],
+          second_question.id => [second_choice.option_number]
+        }
+        expect(subject).to eq(result)
+      end
+    end
+
+    context 'choice_ids が空の場合' do
+      let(:choice_ids) { [] }
+
+      it '空のハッシュを返す' do
+        expect(subject).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
対応するissue
---
Closes #64 

概要
---

小テスト機能の回答確認機能を実装しました。小テストは試験歴（`examinaiton`)に含めたくないので`user_responses_controller`等を使用せずに回答を確認できるようにしています。

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `POST   /mini_tests`| `mini_tests#create` | 回答を表示する |


UI の比較
----

[![Image from Gyazo](https://i.gyazo.com/afb11f6c340ed770456bab78cc3c5be0.gif)](https://gyazo.com/afb11f6c340ed770456bab78cc3c5be0)



実装の詳細
----

- 実装の詳細を書いてください
- コードの細かい説明はプルリクの該当するコードにコメントしてください

追加した Gem
---

- ありません。

備考
---

turboでページ遷移せずに回答を確認できるようにしました。