### PR TITLE
ゲストユーザーの機能制限を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,10 @@ gem 'bootsnap', require: false
 gem 'devise'
 gem 'devise-i18n'
 
+# 認可
+gem 'pundit'
 # seed
+
 gem 'seed-fu'
 
 # decorator

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,8 @@ GEM
     public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
+    pundit (2.4.0)
+      activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (3.1.8)
     rack-session (2.0.0)
@@ -416,6 +418,7 @@ DEPENDENCIES
   mysql2
   pg
   puma
+  pundit
   rails (= 7.2)
   rails-controller-testing
   rspec-rails

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,8 +1,8 @@
 class AccountsController < ApplicationController
   before_action :authenticate_user!
   def show
-    return unless current_user.guest?
-
+    authorize :account, :show?
+  rescue StandardError
     redirect_to tests_select_path, alert: 'ゲストユーザーはアカウント情報を確認できません。'
   end
 end

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,4 +1,8 @@
 class AccountsController < ApplicationController
   before_action :authenticate_user!
-  def show; end
+  def show
+    return unless current_user.guest?
+
+    redirect_to tests_select_path, alert: 'ゲストユーザーはアカウント情報を確認できません。'
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   include Draper::Decoratable
+  include Pundit::Authorization
 
   protected
 

--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -2,6 +2,7 @@ class MiniTestsController < ApplicationController
   before_action :authenticate_user!
   def index
     form = MiniTestSearchForm.new(params)
+    authorize :mini_test, :index?
     if form.valid?
       @questions = form.search
       @user_responses = []

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,4 +46,8 @@ class User < ApplicationRecord
     # ゲストユーザーのメールアドレスの型をチェック
     email.start_with?('guest_') && email.end_with?('@example.com')
   end
+
+  def not_guest?
+    !guest?
+  end
 end

--- a/app/policies/account_policy.rb
+++ b/app/policies/account_policy.rb
@@ -1,0 +1,5 @@
+class AccountPolicy < ApplicationPolicy
+  def show?
+    user.not_guest?
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/mini_test_policy.rb
+++ b/app/policies/mini_test_policy.rb
@@ -1,0 +1,5 @@
+class MiniTestPolicy < ApplicationPolicy
+  def index?
+    user.not_guest?
+  end
+end

--- a/app/views/tests/selections/index.html.erb
+++ b/app/views/tests/selections/index.html.erb
@@ -34,7 +34,21 @@
             <%= image_tag 'tag.png', size: 50 %>
             <h2 class='font-bold text-xl text-gray-900 ml-3'>タグから選択</h2>
           </div>
-          <div class='mt-3'>
+          <% unless policy(:mini_test).index? %>
+          <div class='mt-3 text-center text-lg '>
+            <span class='font-bold bg-red-100'>小テスト機能はゲストユーザーでは利用できません。</span>
+            <span class='font-bold'>ユーザー登録を行ってください。</span>
+          </div>
+          <div class='mt-3 flex justify-center'>
+            <%= link_to new_user_registration_path,
+                        class: 'inline-block bg-sky-100 text-gray-700 hover:bg-sky-500 hover:text-orange-300
+                                font-bold py-2 px-4 rounded-lg shadow-xl block' do %>
+                無料会員登録
+            <% end %>
+          </div>
+          <% end %>
+          <% if policy(:mini_test).index? %>
+            <div class='mt-3'>
             <%= form_with url: mini_tests_path, method: :get do |f| %>
               <h3 class='font-bold text-gray-900'>問題数を選択</h3>
               <div class='flex flex-wrap justify-start'>
@@ -87,6 +101,7 @@
               </div>
             <% end %>
           </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -28,5 +28,12 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     password { '12345678' }
     password_confirmation { '12345678' }
+
+    trait :guest do
+      username { 'ゲストユーザー' }
+      email { 'guest_user@example.com' }
+      password { '12345678' }
+      password_confirmation { '12345678' }
+    end
   end
 end

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -2,15 +2,23 @@ require 'rails_helper'
 
 RSpec.describe 'Accounts' do
   let(:user) { create(:user) }
-
-  before do
-    sign_in user
-  end
+  let(:guest_user) { create(:user, :guest) }
 
   describe 'GET /show' do
-    it 'returns http success' do
-      get '/account'
-      expect(response).to have_http_status(:success)
+    context 'ゲストユーザーの場合' do
+      it 'リダイレクトされる' do
+        sign_in guest_user
+        get '/account'
+        expect(response).to redirect_to(tests_select_path)
+      end
+    end
+
+    context 'ゲストユーザーではない場合' do
+      it 'returns http success' do
+        sign_in user
+        get '/account'
+        expect(response).to have_http_status(:success)
+      end
     end
   end
 end


### PR DESCRIPTION
対応するissue
---
Closes #89

概要
---

ゲストユーザーに対して以下の制限を加えた

- アカウント情報の確認
- 小テスト機能の利用

UI の比較
----

| アカウントあり |ゲストユーザー | 
|:------:|:------:|
| <a href="https://gyazo.com/060bfd59d97bf96e7eb86d0fb5a5e1a8"><img src="https://i.gyazo.com/060bfd59d97bf96e7eb86d0fb5a5e1a8.png" alt="Image from Gyazo" width="300"/></a> | <a href="https://gyazo.com/cd0347783c74cdb8ebb2cf2dc57cb454"><img src="https://i.gyazo.com/cd0347783c74cdb8ebb2cf2dc57cb454.png" alt="Image from Gyazo" width="300"/></a> | 



実装の詳細
----

- punditによる認可を追加

追加した Gem
---

- [pundit](https://github.com/varvet/pundit)

備考
---

その他になにかあれば