### PR TITLE
[add]Rack::Attackによるレート制限機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'tailwindcss-rails'
 gem 'jbuilder'
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", "~> 4.0"
+gem 'redis', '>= 4.0.1'
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
@@ -65,6 +65,9 @@ gem 'sidekiq'
 
 # Configuration
 gem 'dotenv-rails'
+
+# Rate Limiting
+gem 'rack-attack'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.18)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -278,6 +280,8 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
     redis-client (0.22.2)
       connection_pool
     regexp_parser (2.9.3)
@@ -419,8 +423,10 @@ DEPENDENCIES
   letter_opener_web
   mysql2
   puma
+  rack-attack
   rails (~> 7.2.2)
   rails-controller-testing
+  redis (>= 4.0.1)
   rspec-rails
   rubocop
   rubocop-performance

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,5 +40,8 @@ module App
     # Don't generate system test files.
     config.generators.system_tests = nil
     config.active_job.queue_adapter = :sidekiq
+
+    # Rack::Attackを有効化
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,12 +24,13 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
+    config.cache_store = :redis_cache_store, { url: 'redis://redis:6379/0' }
     config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{2.days.to_i}" }
   else
     config.action_controller.perform_caching = false
 
-    config.cache_store = :null_store
+    # Rack::Attack用にRedisキャッシュストアを使用（キャッシュ無効時でも）
+    config.cache_store = :redis_cache_store, { url: 'redis://redis:6379/0' }
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,7 +68,8 @@ Rails.application.configure do
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  # Redisをキャッシュストアとして使用（Rack::Attack用）
+  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0') }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter = :resque

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  # Rack::Attack用にmemory_storeを使用（テスト環境）
+  config.cache_store = :memory_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class Rack::Attack
+  # Rack::Attackのキャッシュストア設定
+  # Railsのキャッシュストアを使用（環境ごとに適切なストアが設定される）
+  Rack::Attack.cache.store = Rails.cache
+
+  # カスタムレスポンス（日本語メッセージ）
+  self.throttled_responder = lambda do |_env|
+    [
+      429,
+      { 'Content-Type' => 'text/plain' },
+      ['アクセス制限に達しました。しばらく時間をおいてから再度お試しください。']
+    ]
+  end
+
+  ### ユーザー登録のレート制限 ###
+  # 1時間に3回まで（IP単位）
+  throttle('registrations/ip', limit: 3, period: 1.hour) do |req|
+    req.ip if req.path == '/users' && req.post?
+  end
+
+  ### ログイン試行のレート制限 ###
+  # 5分間に5回まで（IP単位）
+  throttle('logins/ip', limit: 5, period: 5.minutes) do |req|
+    req.ip if req.path == '/users/sign_in' && req.post?
+  end
+
+  ### ゲストユーザー作成のレート制限 ###
+  # 1時間に10回まで（IP単位）
+  throttle('guest_sign_in/ip', limit: 10, period: 1.hour) do |req|
+    req.ip if req.path == '/users/guest_sign_in' && req.post?
+  end
+
+  ### 試験提出のレート制限 ###
+  # 5分間に1回まで（ユーザー単位）
+  throttle('user_responses/user', limit: 1, period: 5.minutes) do |req|
+    if req.path == '/user_responses' && req.post?
+      # セッションからユーザーIDを取得
+      # Deviseのwarden経由でユーザーIDを取得
+      req.env['warden']&.user&.id
+    end
+  end
+end

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe 'Rack::Attack' do
+  before do
+    # Rack::Attackのキャッシュをクリア
+    Rack::Attack.cache.store.clear
+  end
+
+  describe 'ユーザー登録のレート制限' do
+    let(:valid_params) do
+      {
+        user: {
+          username: 'testuser',
+          email: 'test@example.com',
+          password: 'password123',
+          password_confirmation: 'password123'
+        }
+      }
+    end
+
+    it '1時間に3回までユーザー登録できる' do
+      3.times do |i|
+        params = valid_params.deep_dup
+        params[:user][:email] = "test#{i}@example.com"
+        post user_registration_path, params: params
+        expect(response).to have_http_status(:see_other).or(have_http_status(:found))
+      end
+    end
+
+    it '1時間に4回目のユーザー登録はレート制限される' do
+      3.times do |i|
+        params = valid_params.deep_dup
+        params[:user][:email] = "test#{i}@example.com"
+        post user_registration_path, params: params
+      end
+
+      params = valid_params.deep_dup
+      params[:user][:email] = 'test3@example.com'
+      post user_registration_path, params: params
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe 'ログイン試行のレート制限' do
+    let(:user) do
+      User.create(
+        username: 'testuser',
+        email: 'test@example.com',
+        password: 'password123',
+        password_confirmation: 'password123'
+      )
+    end
+    let(:login_params) { { user: { email: user.email, password: 'wrongpassword' } } }
+
+    before do
+      user
+    end
+
+    it '5分間に5回までログイン試行できる' do
+      5.times do
+        post user_session_path, params: login_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    it '5分間に6回目のログイン試行はレート制限される' do
+      5.times do
+        post user_session_path, params: login_params
+      end
+
+      post user_session_path, params: login_params
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe 'ゲストユーザー作成のレート制限' do
+    it '1時間に10回までゲストユーザー作成できる' do
+      10.times do
+        post users_guest_sign_in_path
+        expect(response).to have_http_status(:found)
+        delete destroy_user_session_path
+      end
+    end
+
+    it '1時間に11回目のゲストユーザー作成はレート制限される' do
+      10.times do
+        post users_guest_sign_in_path
+        delete destroy_user_session_path
+      end
+
+      post users_guest_sign_in_path
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+
+  describe '試験提出のレート制限' do
+    let(:user) { create(:user) }
+    let(:test) { create(:test) }
+    let(:test_session) { create(:test_session, test: test) }
+    let(:questions) { create_list(:question, 5, test_session: test_session) }
+    let(:choices) do
+      questions.map do |question|
+        create(:choice, question: question, is_correct: true)
+      end
+    end
+    let(:valid_params) do
+      {
+        test_id: test.id,
+        user_response: {
+          choice_ids: choices.map(&:id)
+        }
+      }
+    end
+
+    before do
+      sign_in user
+      choices # データを準備
+    end
+
+    it '5分間に1回まで試験提出できる' do
+      post user_responses_path, params: valid_params
+      expect(response).to have_http_status(:found)
+    end
+
+    it '5分間に2回目の試験提出はレート制限される' do
+      post user_responses_path, params: valid_params
+      expect(response).to have_http_status(:found)
+
+      post user_responses_path, params: valid_params
+      expect(response).to have_http_status(:too_many_requests)
+    end
+  end
+end


### PR DESCRIPTION
対応するissue
---
Closes #108

概要
---

Rack::Attackを導入し、アプリケーションのセキュリティを強化するためのレート制限機能を実装しました。

## 実装したレート制限

1. **ユーザー登録**: 1時間に3回まで（IP単位）
2. **ログイン試行**: 5分間に5回まで（IP単位）
3. **ゲストユーザー作成**: 1時間に10回まで（IP単位）
4. **試験提出**: 5分間に1回まで（ユーザー単位）

レート制限に達した場合は、HTTP 429ステータスコードと日本語のエラーメッセージを返します。

エンドポイント
---

レート制限を適用したエンドポイント：

| エンドポイント | メソッド | 制限内容 | 単位 |
| --- | ---  | --- | --- |
| `/users` | POST | 1時間に3回 | IP |
| `/users/sign_in` | POST | 5分間に5回 | IP |
| `/users/guest_sign_in` | POST | 1時間に10回 | IP |
| `/user_responses` | POST | 5分間に1回 | ユーザー |

実装の詳細
----

### Rack::Attack設定

- **キャッシュストア**: 環境ごとに適切なRedisストアを使用
  - 開発環境: `redis://redis:6379/0`
  - 本番環境: `REDIS_URL`環境変数から取得
  - テスト環境: `memory_store`
- **カスタムレスポンス**: 日本語のエラーメッセージを返す
- **ミドルウェア**: `config/application.rb`でRack::Attackミドルウェアを有効化

### キャッシュストアの変更

- 開発環境でもRack::Attackが動作するよう、キャッシュ無効時でもRedisを使用
- 本番環境でRedisキャッシュストアを設定
- テスト環境ではmemory_storeを使用してテストの独立性を保持

### テスト

- 全てのレート制限ルールに対するRSpecテストを実装
- レート制限内のアクセスとレート制限超過時の動作を検証

追加した Gem
---

- [rack-attack](https://github.com/rack/rack-attack) - レート制限ミドルウェア
- [redis](https://github.com/redis/redis-rb) - Redisクライアント（Rack::Attackのキャッシュストアとして使用）

備考
---

- Sidekiqで既にRedisを使用しているため、追加のインフラ設定は不要
- レート制限の閾値は実際の運用状況に応じて調整可能
- 管理者ユーザーを除外する等の追加ルールも必要に応じて実装可能