### PR TITLE
Pundit gemによる認可機能を実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ gem 'bootsnap', require: false
 gem 'devise'
 gem 'devise-i18n'
 
+# 認可
+gem 'pundit'
+
 # seed
 gem 'seed-fu'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,8 @@ GEM
     public_suffix (6.0.1)
     puma (6.5.0)
       nio4r (~> 2.0)
+    pundit (2.5.2)
+      activesupport (>= 3.0.0)
     racc (1.8.1)
     rack (3.1.18)
     rack-attack (6.8.0)
@@ -423,6 +425,7 @@ DEPENDENCIES
   letter_opener_web
   mysql2
   puma
+  pundit
   rack-attack
   rails (~> 7.2.2)
   rails-controller-testing

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -1,3 +1,5 @@
 class AccountsController < ApplicationController
+  before_action :authenticate_user!
+
   def show; end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   include Draper::Decoratable
+  include Pundit::Authorization
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
   protected
 
@@ -12,5 +16,17 @@ class ApplicationController < ActionController::Base
   # Devise認証失敗時のリダイレクト先をカスタマイズ
   def after_sign_in_path_for(resource)
     stored_location_for(resource) || root_path
+  end
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = 'この操作を実行する権限がありません。'
+    redirect_to(request.referer || root_path)
+  end
+
+  def record_not_found
+    flash[:alert] = '指定されたデータが見つかりませんでした。'
+    redirect_to(request.referer || root_path)
   end
 end

--- a/app/controllers/examinations_controller.rb
+++ b/app/controllers/examinations_controller.rb
@@ -1,6 +1,9 @@
 class ExaminationsController < ApplicationController
+  before_action :authenticate_user!
+
   def show
     @examination = current_user.examinations.find(params[:id])
+    authorize @examination
     @score = @examination.score
     @test = @examination.test
     # 参考：https://zenn.dev/mithuami/articles/c4b0e9694182d1#preload%E3%82%92%E6%8E%A8%E5%A5%A8%E3%81%99%E3%82%8B%E3%82%B1%E3%83%BC%E3%82%B9

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,7 +1,10 @@
 class ScoresController < ApplicationController
+  before_action :authenticate_user!
+
   def show
     @examination = Examination.find(params[:examination_id])
     @score = @examination.score
+    authorize @score
 
     return unless @score.nil?
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      raise NoMethodError, "You must define #resolve in #{self.class}"
+    end
+
+    private
+
+    attr_reader :user, :scope
+  end
+end

--- a/app/policies/examination_policy.rb
+++ b/app/policies/examination_policy.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class ExaminationPolicy < ApplicationPolicy
+  # 一覧表示は自分のexaminationsのみ
+  def index?
+    true
+  end
+
+  # 詳細表示は所有者のみ
+  def show?
+    record.user == user
+  end
+
+  # 新規作成は認証済みユーザーなら可能
+  def create?
+    user.present?
+  end
+
+  def new?
+    create?
+  end
+
+  # 試験結果の更新は不可
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  # 削除は所有者のみ
+  def destroy?
+    record.user == user
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.where(user: user)
+    end
+  end
+end

--- a/app/policies/score_policy.rb
+++ b/app/policies/score_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ScorePolicy < ApplicationPolicy
+  # スコアの詳細表示は、そのスコアに紐づくexaminationの所有者のみ
+  def show?
+    record.examination.user == user
+  end
+
+  # スコアの作成・更新・削除は不可（システムが自動生成）
+  def create?
+    false
+  end
+
+  def update?
+    false
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope < ApplicationPolicy::Scope
+    def resolve
+      scope.joins(:examination).where(examinations: { user: user })
+    end
+  end
+end

--- a/spec/policies/examination_policy_spec.rb
+++ b/spec/policies/examination_policy_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExaminationPolicy do
+  subject(:policy) { described_class.new(user, examination) }
+
+  let(:test) { create(:test) }
+  let(:examination) { create(:examination, user: examination_owner, test:) }
+
+  context '所有者の場合' do
+    let(:examination_owner) { create(:user) }
+    let(:user) { examination_owner }
+
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to permit_action(:destroy) }
+    it { is_expected.to forbid_action(:update) }
+    it { is_expected.to forbid_action(:edit) }
+  end
+
+  context '他のユーザーの場合' do
+    let(:examination_owner) { create(:user) }
+    let(:user) { create(:user) }
+
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to permit_action(:index) }
+    it { is_expected.to permit_action(:create) }
+    it { is_expected.to permit_action(:new) }
+    it { is_expected.to forbid_action(:destroy) }
+    it { is_expected.to forbid_action(:update) }
+    it { is_expected.to forbid_action(:edit) }
+  end
+
+  describe 'Scope' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:examination_owner) { user }
+
+    before do
+      create(:examination, user:, test:)
+      create(:examination, user: other_user, test:)
+    end
+
+    it '自分のexaminationsのみを返す' do
+      scope = described_class::Scope.new(user, Examination.all).resolve
+      expect(scope).to all(have_attributes(user:))
+      expect(scope.count).to eq(1)
+    end
+  end
+end

--- a/spec/policies/score_policy_spec.rb
+++ b/spec/policies/score_policy_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScorePolicy do
+  subject(:policy) { described_class.new(user, score) }
+
+  let(:test) { create(:test) }
+  let(:examination) { create(:examination, user: examination_owner, test:) }
+  let(:score) { create(:score, examination:) }
+
+  context '所有者の場合' do
+    let(:examination_owner) { create(:user) }
+    let(:user) { examination_owner }
+
+    it { is_expected.to permit_action(:show) }
+    it { is_expected.to forbid_action(:create) }
+    it { is_expected.to forbid_action(:update) }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  context '他のユーザーの場合' do
+    let(:examination_owner) { create(:user) }
+    let(:user) { create(:user) }
+
+    it { is_expected.to forbid_action(:show) }
+    it { is_expected.to forbid_action(:create) }
+    it { is_expected.to forbid_action(:update) }
+    it { is_expected.to forbid_action(:destroy) }
+  end
+
+  describe 'Scope' do
+    let(:user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:examination_owner) { user }
+    let(:other_examination) { create(:examination, user: other_user, test:) }
+
+    before do
+      create(:score, examination:)
+      create(:score, examination: other_examination)
+    end
+
+    it '自分のscoresのみを返す' do
+      scope = described_class::Scope.new(user, Score.all).resolve
+      expect(scope).to all(have_attributes(examination: have_attributes(user:)))
+      expect(scope.count).to eq(1)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,7 +21,7 @@ require 'capybara/rspec'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
+Rails.root.glob('spec/support/**/*.rb').sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/requests/examinations_spec.rb
+++ b/spec/requests/examinations_spec.rb
@@ -12,13 +12,37 @@ RSpec.describe 'Examinations' do
     let!(:choice) { create(:choice, question:) }
     let!(:user_response) { create(:user_response, examination:, choice:) }
 
-    before do
-      sign_in user
+    context '自分のexaminationにアクセスする場合' do
+      before do
+        sign_in user
+      end
+
+      it '正常にアクセスできる' do
+        get examination_path(examination)
+        expect(response).to have_http_status(:ok)
+      end
     end
 
-    it 'returns http success' do
-      get examination_path(examination)
-      expect(response).to have_http_status(:ok)
+    context '他人のexaminationにアクセスしようとする場合' do
+      let(:other_user) { create(:user) }
+      let(:other_examination) { create(:examination, test:, user: other_user) }
+
+      before do
+        sign_in other_user
+      end
+
+      it 'アラートと共にリダイレクトされる' do
+        get examination_path(examination)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('指定されたデータが見つかりませんでした。')
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'サインインページにリダイレクトされる' do
+        get examination_path(examination)
+        expect(response).to redirect_to(new_user_session_path)
+      end
     end
   end
 end

--- a/spec/requests/scores_spec.rb
+++ b/spec/requests/scores_spec.rb
@@ -1,5 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe 'Scores' do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'GET /examinations/:examination_id/scores/:id' do
+    let(:user) { create(:user) }
+    let(:test) { create(:test) }
+    let(:examination) { create(:examination, test:, user:) }
+    let!(:score) { create(:score, examination:) }
+
+    context '自分のscoreにアクセスする場合' do
+      before do
+        sign_in user
+      end
+
+      it '正常にアクセスできる' do
+        get examination_score_path(examination, score)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context '他人のscoreにアクセスしようとする場合' do
+      let(:other_user) { create(:user) }
+
+      before do
+        sign_in other_user
+      end
+
+      it 'アラートと共にリダイレクトされる' do
+        get examination_score_path(examination, score)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('この操作を実行する権限がありません。')
+      end
+    end
+
+    context '未ログインの場合' do
+      it 'サインインページにリダイレクトされる' do
+        get examination_score_path(examination, score)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end

--- a/spec/support/pundit_matchers.rb
+++ b/spec/support/pundit_matchers.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define :permit_action do |action|
+  match do |policy|
+    policy.public_send(:"#{action}?")
+  end
+
+  failure_message do |policy|
+    "#{policy.class} does not permit #{action} on #{policy.record} for #{policy.user.inspect}."
+  end
+
+  failure_message_when_negated do |policy|
+    "#{policy.class} does not forbid #{action} on #{policy.record} for #{policy.user.inspect}."
+  end
+end
+
+RSpec::Matchers.define :forbid_action do |action|
+  match do |policy|
+    !policy.public_send(:"#{action}?")
+  end
+
+  failure_message do |policy|
+    "#{policy.class} does not forbid #{action} on #{policy.record} for #{policy.user.inspect}."
+  end
+
+  failure_message_when_negated do |policy|
+    "#{policy.class} does not permit #{action} on #{policy.record} for #{policy.user.inspect}."
+  end
+end


### PR DESCRIPTION
## 対応するissue
Closes #116

## 概要
Pundit gemを導入して認可（Authorization）機能を実装しました。これにより、ユーザーが他人の試験結果やスコアに不正アクセスできないようにセキュリティを強化しました。

## 実装の詳細

### 追加された機能

#### 1. Pundit gemの導入
- 認可制御のためのポリシーベースの権限管理システムを実装

#### 2. ポリシークラスの作成
- **ApplicationPolicy**: 全てのポリシーの基底クラス
- **ExaminationPolicy**: 試験結果への認可ルール
  - 所有者のみが閲覧・削除可能
  - 試験結果の更新は不可（immutable）
- **ScorePolicy**: スコアへの認可ルール
  - 所有者のみが閲覧可能
  - スコアの作成・更新・削除は不可（システムが自動生成）

#### 3. コントローラーへの認可チェック追加
- **ExaminationsController**: 
  - `authenticate_user!`で認証チェック
  - `authorize @examination`で認可チェック
- **ScoresController**: 
  - `authenticate_user!`で認証チェック
  - `authorize @score`で認可チェック
- **AccountsController**: 
  - `authenticate_user!`で認証チェック（current_userのみアクセス可能）

#### 4. エラーハンドリングの改善
- `Pundit::NotAuthorizedError`をrescueして適切なエラーメッセージを表示
- `ActiveRecord::RecordNotFound`をrescueして404ページの代わりにユーザーフレンドリーなメッセージを表示

### テストの追加

#### ポリシーテスト
- `ExaminationPolicy`の全アクションテスト（所有者/非所有者のケース）
- `ScorePolicy`の全アクションテスト（所有者/非所有者のケース）
- Pundit用カスタムマッチャー（`permit_action`/`forbid_action`）を実装

#### リクエストテスト
- `Examinations`: 他人のデータへのアクセス試行時のテスト追加
- `Scores`: 他人のデータへのアクセス試行時のテスト追加

## セキュリティ向上

### 修正前の脆弱性
- 認証（ログインチェック）はあったが、認可（権限チェック）が不足
- URLを直接操作することで他人のデータにアクセスできる可能性

### 修正後の動作
- ユーザーは自分の`examination`と`score`のみアクセス可能
- 他人のデータへのアクセス試行時は「指定されたデータが見つかりませんでした。」というメッセージと共にリダイレクト
- 404エラーページではなく、適切なフラッシュメッセージでUXを向上

## エンドポイント
変更なし（既存のエンドポイントに認可チェックを追加）

| エンドポイント | コントローラ#アクション | 変更内容 |
| --- | ---  | --- |
| `GET /examinations/:id`| `examinations#show` | 認証・認可チェック追加 |
| `GET /examinations/:examination_id/scores/:id`| `scores#show` | 認証・認可チェック追加 |
| `GET /account`| `accounts#show` | 認証チェック追加 |

## 追加した Gem
- [pundit](https://github.com/varvet/pundit) - シンプルで堅牢な認可システム

## テスト結果
```
113 examples, 0 failures
```

全てのテストがパスし、既存機能への影響はありません。

## 備考
- `current_user.examinations.find(params[:id])`は既に安全な実装でしたが、`authorize`を追加することでより明示的な認可チェックとなりました
- ポリシークラスは今後の権限管理の拡張に対応しやすい設計になっています