### PR TITLE
Feature/add authentication to controllers

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,4 +1,6 @@
 class DashboardController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     # current_userの最新のexamaminationを取得
     @latest_examination = current_user.examinations.order(created_at: :desc).first

--- a/app/controllers/user_responses_controller.rb
+++ b/app/controllers/user_responses_controller.rb
@@ -1,4 +1,6 @@
 class UserResponsesController < ApplicationController
+  before_action :authenticate_user!
+
   def create # rubocop:disable Metrics/MethodLength
     ActiveRecord::Base.transaction do
       Examination.create_result!(user_id: current_user.id,

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -8,13 +8,22 @@ RSpec.describe 'Dashboards' do
     let!(:examination) { create(:examination, test:, user:) }
     let!(:score) { create(:score, examination:) }
 
-    before do
-      sign_in user
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      it 'returns http success' do
+        get '/dashboard'
+        expect(response).to have_http_status(:success)
+      end
     end
 
-    it 'returns http success' do
-      get '/dashboard'
-      expect(response).to have_http_status(:success)
+    context '未認証ユーザーの場合' do
+      it 'ログインページにリダイレクトされる' do
+        get '/dashboard'
+        expect(response).to redirect_to(new_user_session_path)
+      end
     end
   end
 end

--- a/spec/requests/user_responses_spec.rb
+++ b/spec/requests/user_responses_spec.rb
@@ -14,31 +14,40 @@ RSpec.describe 'UserResponses' do
       }
     end
 
-    before do
-      sign_in user
+    context '認証済みユーザーの場合' do
+      before do
+        sign_in user
+      end
+
+      context '正常系' do
+        before do
+          allow(Examination).to receive(:create_result!)
+        end
+
+        it 'user_responseが作成されリダイレクトされる' do
+          post(user_responses_path, params:)
+          expect(response).to redirect_to(dashboard_path)
+          expect(flash[:notice]).to eq '試験結果を保存しました'
+        end
+      end
+
+      context '異常系' do
+        before do
+          allow(Examination).to receive(:create_result!).and_raise(StandardError)
+        end
+
+        it 'newテンプレートがレンダリングされ、エラーメッセージが表示される' do
+          post(user_responses_path, params:)
+          expect(response).to redirect_to(test_path(params[:test_id]))
+          expect(flash[:alert]).to eq '試験結果を保存できませんでした'
+        end
+      end
     end
 
-    context '正常系' do
-      before do
-        allow(Examination).to receive(:create_result!)
-      end
-
-      it 'user_responseが作成されリダイレクトされる' do
+    context '未認証ユーザーの場合' do
+      it 'ログインページにリダイレクトされる' do
         post(user_responses_path, params:)
-        expect(response).to redirect_to(dashboard_path)
-        expect(flash[:notice]).to eq '試験結果を保存しました'
-      end
-    end
-
-    context '異常系' do
-      before do
-        allow(Examination).to receive(:create_result!).and_raise(StandardError)
-      end
-
-      it 'newテンプレートがレンダリングされ、エラーメッセージが表示される' do
-        post(user_responses_path, params:)
-        expect(response).to redirect_to(test_path(params[:test_id]))
-        expect(flash[:alert]).to eq '試験結果を保存できませんでした'
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end


### PR DESCRIPTION
対応するissue
---
Closes #114

概要
---
DashboardControllerとUserResponsesControllerに認証機能（`before_action :authenticate_user!`）を追加しました。これにより、未ログインユーザーが個人データにアクセスできないようにセキュリティを強化しました。

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 | 認証 |
| --- | ---  | --- | --- |
| `GET /dashboard`| `dashboard#index` | ダッシュボード画面を表示する | ✅ 必須 |
| `POST /user_responses`| `user_responses#create` | 試験回答を保存する | ✅ 必須 |

実装の詳細
----

### コントローラー
- `DashboardController`に`before_action :authenticate_user!`を追加（2行目）
- `UserResponsesController`に`before_action :authenticate_user!`を追加（2行目）

### テスト
両コントローラーのリクエストspecに未認証ユーザーのテストケースを追加：
- 未認証時にログインページ（`new_user_session_path`）にリダイレクトされることを確認
- 既存の認証済みユーザーのテストも正常動作を確認

### テスト結果
```bash
bundle exec rspec spec/requests/dashboard_spec.rb spec/requests/user_responses_spec.rb
.....
5 examples, 0 failures
```

### RuboCop
```bash
bundle exec rubocop app/controllers/dashboard_controller.rb app/controllers/user_responses_controller.rb
2 files inspected, no offenses detected
```

追加した Gem
---
なし

備考
---
- MiniTestsControllerのゲストユーザー制限は別Issue #131 として作成済み
- 本PRはセキュリティ脆弱性の修正に焦点を当てています

🤖 Generated with [Claude Code](https://claude.com/claude-code)