### PR TITLE
[add]Content Security Policyを有効化

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,55 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    # デフォルトは自ドメインとHTTPSのみ許可
+    policy.default_src :self, :https
+
+    # フォント: Data URIも許可（Webフォント対応）
+    policy.font_src :self, :https, :data
+
+    # 画像: Data URIとBlob URLも許可（アップロード画像やBase64エンコード対応）
+    policy.img_src :self, :https, :data, :blob
+
+    # オブジェクト埋め込み: 全て禁止（Flash等のレガシー技術対策）
+    policy.object_src :none
+
+    # スクリプト: Import Maps、Turbo、Stimulus対応
+    policy.script_src :self, :https
+
+    # スタイル: Tailwind CSSのインラインスタイル対応
+    policy.style_src :self, :https
+
+    # 開発環境でのHot Reloading対応（WebSocketとローカルホスト接続）
+    if Rails.env.development?
+      policy.connect_src :self, :https, "http://localhost:3035", "ws://localhost:3035"
+    else
+      policy.connect_src :self, :https
+    end
+
+    # フレーム: 同一オリジンのみ許可
+    policy.frame_ancestors :self
+
+    # ベースURI: 同一オリジンのみ許可（ベースタグのインジェクション対策）
+    policy.base_uri :self
+
+    # フォーム送信先: 同一オリジンとHTTPSのみ許可
+    policy.form_action :self, :https
+  end
+
+  # Import Mapsとインラインスクリプト/スタイル用のnonce生成
+  # セッションIDを使用することで、リクエストごとに一意な値を生成
+  config.content_security_policy_nonce_generator = ->(request) {
+    request.session.id.to_s
+  }
+
+  # nonceを適用するディレクティブを指定
+  # script-src: Import Maps、インラインスクリプト
+  # style-src: Tailwind CSSのインラインスタイル
+  config.content_security_policy_nonce_directives = %w(script-src style-src)
+
+  # 開発環境ではレポートのみ（警告を表示するが実行はブロックしない）
+  # 本番環境では強制モード（違反をブロック）
+  config.content_security_policy_report_only = Rails.env.development?
+end


### PR DESCRIPTION
## 概要
Content Security Policy (CSP) を有効化し、XSS攻撃への防御を強化しました。

## 実装内容
- CSP設定の有効化（すべてのディレクティブを設定）
- Import Maps/Turbo/Stimulus対応
- Tailwind CSSのインラインスタイル対応
- nonce生成設定（セッションIDを使用）
- 開発環境ではreport-onlyモード、本番環境では強制モード

## セキュリティ対策
- XSS攻撃への防御
- クリックジャッキング対策（frame-ancestors）
- ベースタグインジェクション対策（base-uri）
- レガシー技術の無効化（object-src）

## 動作確認
- ブラウザコンソールでCSP警告が出ないことを確認済み
- CSPヘッダーが正常に送信されることを確認済み

## 関連Issue
Closes #109