### PR TITLE
[修正] Miniテスト入力バリデーション強化

### DIFF
--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -1,4 +1,7 @@
 class MiniTestsController < ApplicationController
+  MAX_QUESTIONS = 50
+  MAX_CHOICES = 250
+
   def index
     form = MiniTestSearchForm.new(params)
     if form.valid?
@@ -10,12 +13,16 @@ class MiniTestsController < ApplicationController
   end
 
   def create
-    @selected_answers = Choice.mini_test_answers(sanitized_choice_ids)
-    @questions = Question.where(id: sanitized_question_ids)
+    unique_question_ids = validate_question_ids!(sanitized_question_ids)
+    unique_choice_ids = validate_choice_ids!(sanitized_choice_ids)
+
+    load_mini_test_resources(unique_question_ids, unique_choice_ids)
 
     respond_to do |format|
       format.turbo_stream
     end
+  rescue ValidationError => e
+    redirect_to tests_select_path, alert: e.message
   end
 
   private
@@ -39,4 +46,44 @@ class MiniTestsController < ApplicationController
       .select { |id| id.to_s =~ /\A\d+\z/ }
       .map(&:to_i)
   end
+
+  def load_mini_test_resources(question_ids, choice_ids)
+    @questions = Question.where(id: question_ids)
+    validate_question_existence!(question_ids, @questions)
+    @selected_answers = Choice.mini_test_answers(choice_ids)
+  end
+
+  def validate_question_ids!(question_ids)
+    raise ValidationError, '問題が選択されていません' if question_ids.blank?
+    raise ValidationError, "問題数が多すぎます（最大#{MAX_QUESTIONS}問）" if question_ids.size > MAX_QUESTIONS
+
+    unique_ids = question_ids.uniq
+    raise ValidationError, '重複した問題IDが含まれています' if unique_ids.size != question_ids.size
+
+    unique_ids
+  end
+
+  def validate_choice_ids!(choice_ids)
+    raise ValidationError, "回答数が多すぎます（最大#{MAX_CHOICES}）" if choice_ids.size > MAX_CHOICES
+
+    unique_ids = choice_ids.uniq
+    raise ValidationError, '重複した回答IDが含まれています' if unique_ids.size != choice_ids.size
+
+    ensure_choices_exist!(unique_ids)
+  end
+
+  def validate_question_existence!(question_ids, questions)
+    return if questions.size == question_ids.size
+
+    raise ValidationError, '存在しない問題が含まれています'
+  end
+
+  def ensure_choices_exist!(choice_ids)
+    choice_ids_in_db = Choice.where(id: choice_ids).pluck(:id)
+    raise ValidationError, '存在しない回答が含まれています' if choice_ids_in_db.size != choice_ids.size
+
+    choice_ids
+  end
+
+  class ValidationError < StandardError; end
 end

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -1,27 +1,43 @@
 class MiniTestSearchForm
   include ActiveModel::Model
 
-  attr_accessor :tag_ids, :question_count
+  MAX_QUESTION_COUNT = 50
+  MAX_TAG_IDS = 26
+  MAX_TEST_IDS = 10
+  DEFAULT_QUESTION_COUNT = 10
+
+  attr_accessor :tag_ids, :test_ids, :question_count
 
   validates :tag_ids, presence: { message: 'タグを選択してください' }
   validates :question_count, numericality: {
     only_integer: true,
     greater_than: 0,
-    less_than_or_equal_to: 200,
-    message: '問題数は1〜200の整数で指定してください'
+    less_than_or_equal_to: MAX_QUESTION_COUNT,
+    message: "問題数は1〜#{MAX_QUESTION_COUNT}の整数で指定してください"
   }
+  validate :tag_ids_within_limit
+  validate :test_ids_within_limit
+  validate :tag_ids_exist
+  validate :test_ids_exist
 
   def initialize(params = {})
     permitted_params = permit_params(params)
     @tag_ids = sanitize_ids(permitted_params.dig(:search, :tag_ids))
+    @test_ids = sanitize_ids(permitted_params.dig(:search, :test_ids))
     @question_count = sanitize_question_count(permitted_params.dig(:search, :question_count))
   end
 
   def search
-    question_ids = Question.joins(:question_tags)
-                           .where(question_tags: { tag_id: tag_ids })
-                           .distinct
-                           .pluck(:id)
+    scope = Question.joins(:question_tags)
+                    .where(question_tags: { tag_id: tag_ids })
+                    .distinct
+
+    if test_ids.present?
+      scope = scope.joins(:test_session)
+                   .where(test_sessions: { test_id: test_ids })
+    end
+
+    question_ids = scope.pluck(:id)
     Question.random_questions(question_ids, question_count)
   end
 
@@ -29,7 +45,7 @@ class MiniTestSearchForm
 
   def permit_params(params)
     if params.respond_to?(:permit)
-      params.permit(search: [:question_count, { tag_ids: [] }])
+      params.permit(search: [:question_count, { tag_ids: [], test_ids: [] }])
     else
       params
     end
@@ -38,12 +54,44 @@ class MiniTestSearchForm
   def sanitize_ids(ids)
     return [] if ids.blank?
 
-    ids.select { |id| id.to_s =~ /\A\d+\z/ }.map(&:to_i)
+    ids.select { |id| id.to_s =~ /\A\d+\z/ }
+       .map(&:to_i)
+       .uniq
   end
 
   def sanitize_question_count(count)
-    return 0 if count.blank?
+    return DEFAULT_QUESTION_COUNT if count.blank?
 
     count.to_i
+  end
+
+  def tag_ids_within_limit
+    return if tag_ids.size <= MAX_TAG_IDS
+
+    errors.add(:tag_ids, "は#{MAX_TAG_IDS}個以下で選択してください")
+  end
+
+  def test_ids_within_limit
+    return if test_ids.size <= MAX_TEST_IDS
+
+    errors.add(:test_ids, "は#{MAX_TEST_IDS}個以下で選択してください")
+  end
+
+  def tag_ids_exist
+    return if tag_ids.blank?
+
+    existing_ids = Tag.where(id: tag_ids).pluck(:id)
+    return if existing_ids.size == tag_ids.size
+
+    errors.add(:tag_ids, 'に存在しないタグが含まれています')
+  end
+
+  def test_ids_exist
+    return if test_ids.blank?
+
+    existing_ids = Test.where(id: test_ids).pluck(:id)
+    return if existing_ids.size == test_ids.size
+
+    errors.add(:test_ids, 'に存在しない試験IDが含まれています')
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,9 +30,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :username, presence: true
-  validates :email, presence: true, uniqueness: true
-  validates :password, presence: true, length: { minimum: 6 }
+  validates :username, presence: true, length: { maximum: 50 }
   validate :admin_restrictions
 
   def admin?


### PR DESCRIPTION
対応するissue
---
Closes #117

概要
---
- MiniTestsController に問題数・回答数の上限および重複/存在チェックを追加
- MiniTestSearchForm にタグ/試験IDの上限・存在確認とデフォルト問題数の設定を実装
- UserResponse.bulk_create_responses の入力検証を強化し、User モデルのバリデーションを整理

エンドポイント
---
| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| 変更なし | - | - |

UI の比較
----
| 現状 | figma | 
|:------:|:------:|
| なし | なし |

実装の詳細
----
- MiniTestsController#create で ValidationError 発生時に選択画面へリダイレクトする処理を追加
- MiniTestSearchForm でタグ/試験IDの sanitize と存在確認、件数上限のバリデーションを追加
- UserResponse.bulk_create_responses で重複検知・最大件数チェック・タイムスタンプ付与を実施し、User モデルの username 制約を強化

追加した Gem
---
- なし

備考
---
- 実施テスト: `docker-compose exec web bundle exec rspec`
- Lint: `docker-compose exec web bundle exec rubocop`