### PR TITLE
ゲスト受験上限と自動削除の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ gem 'draper'
 
 # BackGround Job
 gem 'sidekiq'
+gem 'sidekiq-scheduler'
 
 # Configuration
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       rubocop (>= 1)
       smart_properties
     erubi (1.13.1)
+    et-orbi (1.4.0)
+      tzinfo
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.4)
@@ -159,6 +161,9 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    fugit (1.12.1)
+      et-orbi (~> 1.4)
+      raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -232,6 +237,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.5.2)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.8.1)
     rack (3.1.18)
     rack-attack (6.8.0)
@@ -338,6 +344,8 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
     securerandom (0.4.1)
     seed-fu (2.3.9)
       activerecord (>= 3.1)
@@ -351,6 +359,9 @@ GEM
       logger
       rack (>= 2.2.4)
       redis-client (>= 0.22.2)
+    sidekiq-scheduler (6.0.1)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 7.3, < 9)
     smart_properties (1.17.0)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -438,6 +449,7 @@ DEPENDENCIES
   seed-fu
   selenium-webdriver
   sidekiq
+  sidekiq-scheduler
   sprockets-rails
   stimulus-rails
   tailwindcss-rails

--- a/app/controllers/user_responses_controller.rb
+++ b/app/controllers/user_responses_controller.rb
@@ -1,5 +1,6 @@
 class UserResponsesController < ApplicationController
   before_action :authenticate_user!
+  before_action :ensure_guest_can_submit, only: :create
 
   def create # rubocop:disable Metrics/MethodLength
     # rescue内でparams再取得を防ぐため、事前に変数に格納
@@ -35,5 +36,12 @@ class UserResponsesController < ApplicationController
     user_response_params[:choice_ids]
       .select { |id| id.to_s =~ /\A\d+\z/ }
       .map(&:to_i)
+  end
+
+  def ensure_guest_can_submit
+    return unless current_user.guest? && current_user.guest_examination_limit_reached?
+
+    redirect_to dashboard_path,
+                alert: 'ゲストユーザーの受験回数が上限に達しました。受験結果を保持したい場合はアカウントを作成してください。'
   end
 end

--- a/app/jobs/cleanup_guest_users_job.rb
+++ b/app/jobs/cleanup_guest_users_job.rb
@@ -1,0 +1,9 @@
+class CleanupGuestUsersJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    deleted = User.cleanup_old_guests!
+    Rails.logger.info("CleanupGuestUsersJob deleted #{deleted} old guest users")
+    deleted
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@
 #  confirmed_at           :datetime
 #  email                  :string(255)      default(""), not null
 #  encrypted_password     :string(255)      default(""), not null
+#  guest_limit_reached_at :datetime
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
@@ -19,11 +20,17 @@
 #
 # Indexes
 #
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_confirmation_token      (confirmation_token) UNIQUE
+#  index_users_on_email                   (email) UNIQUE
+#  index_users_on_guest_limit_reached_at  (guest_limit_reached_at)
+#  index_users_on_reset_password_token    (reset_password_token) UNIQUE
 #
 class User < ApplicationRecord
+  GUEST_EMAIL_PREFIX = 'guest_'.freeze
+  GUEST_EMAIL_DOMAIN = '@example.com'.freeze
+  GUEST_EXAM_LIMIT = 5
+  GUEST_RETENTION_PERIOD = 7.days
+
   has_many :examinations, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -32,6 +39,11 @@ class User < ApplicationRecord
 
   validates :username, presence: true, length: { maximum: 50 }
   validate :admin_restrictions
+
+  scope :guest_users, -> { where('email LIKE ?', "#{GUEST_EMAIL_PREFIX}%#{GUEST_EMAIL_DOMAIN}") }
+  scope :old_guest_users, lambda {
+    guest_users.where(created_at: ...GUEST_RETENTION_PERIOD.ago)
+  }
 
   def admin?
     admin
@@ -43,12 +55,39 @@ class User < ApplicationRecord
       user.email = unique_email
       user.username = 'ゲストユーザー'
       user.password = SecureRandom.urlsafe_base64
+      user.guest_limit_reached_at = nil
     end
   end
 
   def guest?
     # ゲストユーザーのメールアドレスの型をチェック
-    email.start_with?('guest_') && email.end_with?('@example.com')
+    email.start_with?(GUEST_EMAIL_PREFIX) && email.end_with?(GUEST_EMAIL_DOMAIN)
+  end
+
+  def guest_examination_limit_reached?
+    return false unless guest?
+
+    guest_limit_reached? || examinations.count >= GUEST_EXAM_LIMIT
+  end
+
+  def guest_limit_reached?
+    guest_limit_reached_at.present?
+  end
+
+  def mark_guest_limit_reached!
+    return unless guest?
+
+    update!(guest_limit_reached_at: Time.current)
+  end
+
+  # Sidekiqジョブや rake タスクから呼び出し、ゲストを削除する
+  # 破壊的に削除を行い、削除した件数を返す
+  def self.cleanup_old_guests!
+    deleted = 0
+    old_guest_users.find_each do |user|
+      deleted += 1 if user.destroy
+    end
+    deleted
   end
 
   private

--- a/config/initializers/sidekiq_scheduler.rb
+++ b/config/initializers/sidekiq_scheduler.rb
@@ -1,0 +1,25 @@
+begin
+  require 'sidekiq-scheduler'
+rescue LoadError
+  nil
+end
+
+if defined?(Sidekiq) && defined?(Sidekiq::Scheduler)
+  scheduler_enabled = ENV.fetch('ENABLE_SIDEKIQ_SCHEDULER', 'true') == 'true'
+
+  if scheduler_enabled
+    Sidekiq.configure_server do |config|
+      config.on(:startup) do
+        Sidekiq.schedule = {
+          cleanup_guest_users_job: {
+            cron: '0 3 * * *',
+            class: 'CleanupGuestUsersJob',
+            queue: 'default',
+            description: '保持期間を過ぎたゲストユーザーの削除を実行'
+          }
+        }
+        Sidekiq::Scheduler.reload_schedule!
+      end
+    end
+  end
+end

--- a/db/migrate/20251104090000_add_guest_limit_reached_at_to_users.rb
+++ b/db/migrate/20251104090000_add_guest_limit_reached_at_to_users.rb
@@ -1,0 +1,6 @@
+class AddGuestLimitReachedAtToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :guest_limit_reached_at, :datetime
+    add_index :users, :guest_limit_reached_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_10_26_053825) do
+ActiveRecord::Schema[7.2].define(version: 2025_11_04_090000) do
   create_table "choices", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "question_id", null: false
     t.string "content", null: false
@@ -115,8 +115,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_10_26_053825) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
+    t.datetime "guest_limit_reached_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["guest_limit_reached_at"], name: "index_users_on_guest_limit_reached_at"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -1,0 +1,7 @@
+namespace :cleanup do
+  desc '保持期間を過ぎたゲストユーザーを削除する'
+  task guest_users: :environment do
+    deleted_count = User.cleanup_old_guests!
+    puts "Deleted #{deleted_count} old guest user(s)"
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,7 @@
 #  confirmed_at           :datetime
 #  email                  :string(255)      default(""), not null
 #  encrypted_password     :string(255)      default(""), not null
+#  guest_limit_reached_at :datetime
 #  remember_created_at    :datetime
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
@@ -19,9 +20,10 @@
 #
 # Indexes
 #
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_confirmation_token      (confirmation_token) UNIQUE
+#  index_users_on_email                   (email) UNIQUE
+#  index_users_on_guest_limit_reached_at  (guest_limit_reached_at)
+#  index_users_on_reset_password_token    (reset_password_token) UNIQUE
 #
 FactoryBot.define do
   factory :user do

--- a/spec/requests/guest_sessions_spec.rb
+++ b/spec/requests/guest_sessions_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'ゲストユーザーのログアウト', type: :request do
+  let(:guest_user) { create(:user, :guest) }
+  let(:exam_limit) { 5 }
+
+  before do
+    sign_in guest_user
+  end
+
+  describe 'DELETE /users/sign_out' do
+    context '受験回数が上限未満の場合' do
+      it 'ゲストユーザーは削除されない' do
+        delete destroy_user_session_path
+        expect(User.exists?(guest_user.id)).to be true
+      end
+    end
+
+    context '受験回数が上限に達している場合' do
+      before do
+        create_list(:examination, exam_limit, user: guest_user)
+      end
+
+      it 'ログアウト後にゲストユーザーが削除される' do
+        delete destroy_user_session_path
+        expect(User.exists?(guest_user.id)).to be false
+      end
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'Users::sessions' do
     it 'ゲストユーザーからログアウトできる' do
       delete users_guest_sign_out_path
       expect(response).to redirect_to(root_path)
-      expect(response).to have_http_status(:found)
+      expect(response).to have_http_status(:see_other)
     end
   end
 end


### PR DESCRIPTION
対応するissue
---
Closes #111

概要
---
- ゲストユーザーの受験回数を最大5回に制限し、上限到達後はログアウト時にアカウントを自動削除するようにしました。
- ゲスト作成から7日を超えたアカウントを定期的に削除する Sidekiq ジョブと Rake タスクを追加しました。
- 受験上限や削除ロジックをモデル／コントローラ／テストに落とし込み、ゲスト利用のガイド文言も調整しました。

エンドポイント
---
なし（既存エンドポイントの挙動のみ調整）

UI の比較
----
なし

実装の詳細
----
- users/sessions#destroy・guest_sign_out でゲスト上限到達時の削除を実行。
- UserResponsesController で上限到達済みゲストの受験リクエストをガードし、案内文を更新。
- User モデルにゲスト判定スコープ、guest_limit_reached_at、 自動削除メソッドを追加。
- CleanupGuestUsersJob、cleanup:guest_users、sidekiq-scheduler 設定で 7 日超ゲストを定期削除。
- 受験上限・ログアウト削除をカバーするモデル / リクエストスペックを追加。

追加した Gem
---
- [sidekiq-scheduler](https://github.com/sidekiq-scheduler/sidekiq-scheduler)

備考
---
- docker-compose exec web bundle exec rspec
- docker-compose exec web bundle exec rubocop
