### PR TITLE
ゲスト編集で current_password をスキップ

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,9 +20,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # PUT /resource
-  # def update
-  #   super
-  # end
+  def update
+    @guest_upgrading = current_user&.guest?
+    super
+  end
 
   # DELETE /resource
   # def destroy
@@ -39,6 +40,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # end
 
   # protected
+  def update_resource(resource, params)
+    return super unless resource.guest?
+
+    resource.update_without_password(params.merge(guest_limit_reached_at: nil))
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
@@ -58,5 +64,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # The path used after sign up for inactive accounts.
   def after_inactive_sign_up_path_for(_resource)
     edit_user_registration_path
+  end
+
+  def set_flash_message_for_update(resource, prev_unconfirmed_email)
+    if @guest_upgrading
+      flash[:notice] = '本登録が完了しました。これまでの試験結果を引き継いで利用できます。'
+    else
+      super
+    end
   end
 end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Users::registrations' do
   let(:user) { create(:user) }
+  let(:guest_user) { create(:user, :guest, guest_limit_reached_at: Time.current) }
 
   describe 'GET /users/sign_up' do
     it 'ユーザー登録画面が表示される' do
@@ -35,6 +36,57 @@ RSpec.describe 'Users::registrations' do
           post user_registration_path, params: invalid_user_params
         end.not_to change(User, :count)
         expect(response).to render_template(:new)
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'PUT /users' do
+    context 'ゲストユーザーが本登録情報へ更新する場合' do
+      let(:guest_params) do
+        {
+          user: {
+            username: '本登録ユーザー',
+            email: 'member@example.com',
+            password: 'guestupdate',
+            password_confirmation: 'guestupdate'
+          }
+        }
+      end
+
+      before { sign_in guest_user }
+
+      it 'current_passwordなしで更新できてゲスト属性が解除される' do
+        put user_registration_path, params: guest_params
+
+        expect(response).to have_http_status(:see_other)
+        expect(flash[:notice]).to eq('本登録が完了しました。これまでの試験結果を引き継いで利用できます。')
+
+        guest_user.reload
+        expect(guest_user.username).to eq('本登録ユーザー')
+        expect(guest_user.email).to eq('member@example.com')
+        expect(guest_user.guest?).to be(false)
+        expect(guest_user.guest_limit_reached_at).to be_nil
+      end
+    end
+
+    context '通常ユーザーが current_password を送らない場合' do
+      let(:update_params) do
+        {
+          user: {
+            username: '変更後ユーザー',
+            email: 'changed@example.com'
+          }
+        }
+      end
+
+      before { sign_in user }
+
+      it '更新に失敗する' do
+        expect do
+          put user_registration_path, params: update_params
+        end.not_to(change { user.reload.username })
+
         expect(response).to have_http_status(:unprocessable_entity)
       end
     end


### PR DESCRIPTION
対応するissue
---
Closes #144

概要
---
- ゲストユーザーが current_password を知らなくても本登録へ移行できるよう RegistrationsController を拡張
- 成功時フラッシュを本登録完了メッセージへ差し替え、ゲスト専用フラグ `guest_limit_reached_at` をリセット
- リクエストスペックでゲスト成功・通常ユーザー失敗パターンを追加

エンドポイント
---
| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `PUT /users`| `users/registrations#update` | アカウント情報更新（ゲストは current_password 免除） |

UI の比較
----
| 現状 | figma | 
|:------:|:------:|
| なし | なし |


実装の詳細
----
- `Users::RegistrationsController#update_resource` をオーバーライドし、`guest?` の場合に `update_without_password` + `guest_limit_reached_at` リセットを実行
- 成功フラッシュをゲスト本登録専用文言に変更
- `spec/requests/users/registration_spec.rb` にゲスト更新成功・通常ユーザー失敗のシナリオを追加

追加した Gem
---
- なし

備考
---
- 実行したテスト: `docker-compose exec web bundle exec rspec spec/requests/users/registration_spec.rb`
- Lint: `docker-compose exec web bundle exec rubocop`
