### PR TITLE
[改善] examinations#show の質問取得で発生するN+1を解消

### DIFF
--- a/app/controllers/examinations_controller.rb
+++ b/app/controllers/examinations_controller.rb
@@ -6,7 +6,9 @@ class ExaminationsController < ApplicationController
     authorize @examination
     @score = @examination.score
     @test = @examination.test
-    # 参考：https://zenn.dev/mithuami/articles/c4b0e9694182d1#preload%E3%82%92%E6%8E%A8%E5%A5%A8%E3%81%99%E3%82%8B%E3%82%B1%E3%83%BC%E3%82%B9
-    @questions = @test.test_sessions.preload(questions: :choices).map(&:questions).flatten
+    @questions = Question.includes(:choices, :test_session)
+                         .joins(:test_session)
+                         .where(test_sessions: { test_id: @test.id })
+                         .order(:question_number)
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -28,7 +28,7 @@ class Question < ApplicationRecord
   validates :question_number, presence: true
 
   def correct_option_numbers
-    choices.where(is_correct: true).pluck(:option_number)
+    choices.select(&:is_correct).map(&:option_number)
   end
 
   # questionに対応する回答を取得する


### PR DESCRIPTION
対応するissue
---
Closes #151

概要
---
- examinations#show で Question.includes(:choices, :test_session) を用いて試験に属する問題を一括取得し、無駄な flatten を廃止しました。
- Question#correct_option_numbers は eager load 済みの choices コレクションを利用して SQL を再発行しないようにしました。

エンドポイント
---
| エンドポイント | コントローラ#アクション | 役割 |
| --- | --- | --- |
| `GET /examinations/:id` | `examinations#show` | 受験結果を表示する |

UI の比較
----
なし

実装の詳細
----
- Bullet が指摘した Question => [:choices] の「Avoid eager loading」を解消するため、includes 済みの関連を直接参照する実装に改めています。
- 取得した問題は question_number 順で整列し、既存 UI の表示順序を保証しています。

追加した Gem
---
なし

備考
---
- `docker-compose exec web bundle exec rspec spec/requests/examinations_spec.rb`
