### PR TITLE
[修正] guest logout のExamination N+1を回避

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -59,6 +59,8 @@ class Users::SessionsController < Devise::SessionsController
     return unless user&.guest?
     return unless force || user.guest_limit_reached?
 
+    # N+1回避のため、関連を先に読み込んでから削除する
+    user.examinations.includes(:user_responses).load
     user.destroy
   end
 end


### PR DESCRIPTION
対応するissue
---
Closes #154

概要
---
ゲストログアウト時にExaminationのuser_responsesを事前ロードしてN+1を回避。

エンドポイント
---
| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| なし | なし | なし |


UI の比較
----
| 現状 | figma | 
|:------:|:------:|
| なし | なし | 



実装の詳細
----
- Users::SessionsController#cleanup_guest_userでuser.examinations.includes(:user_responses).loadを追加し、destroy前にEager load

追加した Gem
---
- なし

備考
---
- 実行したテスト: docker-compose exec web bundle exec rspec spec/requests/guest_sessions_spec.rb
