### PR TITLE
[修正] MiniTestsのN+1解消

### DIFF
--- a/app/controllers/mini_tests_controller.rb
+++ b/app/controllers/mini_tests_controller.rb
@@ -48,7 +48,8 @@ class MiniTestsController < ApplicationController
   end
 
   def load_mini_test_resources(question_ids, choice_ids)
-    @questions = Question.where(id: question_ids)
+    @questions = Question.includes(:choices, test_session: :test)
+                         .where(id: question_ids)
     validate_question_existence!(question_ids, @questions)
     @selected_answers = Choice.mini_test_answers(choice_ids)
   end

--- a/app/forms/mini_test_search_form.rb
+++ b/app/forms/mini_test_search_form.rb
@@ -39,6 +39,7 @@ class MiniTestSearchForm
 
     question_ids = scope.pluck(:id)
     Question.random_questions(question_ids, question_count)
+            .includes(:choices, :tags, test_session: :test)
   end
 
   private


### PR DESCRIPTION
対応するissue
---
Closes #153

概要
---
MiniTestsの検索・回答表示で参照する関連を事前ロードし、BulletのN+1検出を解消しました。

エンドポイント
---
| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `GET /mini_tests` | `mini_tests#index` | ミニテスト検索結果を表示する |
| `POST /mini_tests` | `mini_tests#create` | 回答結果を表示する |

UI の比較
----
| 現状 | figma | 
|:------:|:------:|
| なし | なし |

実装の詳細
----
- `MiniTestSearchForm#search` で `choices/tags/test_session.test` を eager load
- `MiniTestsController#load_mini_test_resources` で `choices/test_session.test` を eager load

追加した Gem
---
- なし

備考
---
- `docker-compose exec web bundle exec rspec spec/requests/mini_tests_spec.rb`
