### PR TITLE
Renderデプロイに向けたDB変更

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -7,13 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     services:
       db:
-        image: mysql:8.4.3
+        image: postgres:16
         ports:
-          - 3306:3306
+          - 5432:5432
         env:
           TZ: "Asia/Tokyo"
-          MYSQL_ROOT_PASSWORD: password
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+        options: --health-cmd="pg_isready -U postgres" --health-interval=5s --health-timeout=2s --health-retries=5
     container:
       image: ruby:3.3.8
       env:

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'rails', '~> 7.2.2'
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem 'sprockets-rails'
 
-# Use mysql as the database for Active Record
-gem 'mysql2'
+# Use PostgreSQL as the database for Active Record
+gem 'pg'
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.26.0)
     msgpack (1.7.5)
-    mysql2 (0.5.6)
     net-imap (0.5.12)
       date
       net-protocol
@@ -229,6 +228,8 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-arm64-darwin)
     pp (0.6.3)
       prettyprint
     prettyprint (0.2.0)
@@ -445,7 +446,7 @@ DEPENDENCIES
   jbuilder
   launchy
   letter_opener_web
-  mysql2
+  pg
   puma
   pundit
   rack-attack

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,21 +1,18 @@
-# MySQL. Versions 5.5.8 and up are supported.
+# PostgreSQL. Versions 9.3 and up are supported.
 #
-# Install the MySQL driver
-#   gem install mysql2
+# Install the PostgreSQL driver
+#   gem install pg
 #
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem "mysql2"
-#
-# And be sure to use new-style password hashing:
-#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
+# Ensure the pg gem is defined in your Gemfile
+#   gem "pg"
 #
 default: &default
-  adapter: mysql2
-  encoding: utf8mb4
+  adapter: postgresql
+  encoding: unicode
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: root
-  password: password
-  host: db
+  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "password") %>
+  host: <%= ENV.fetch("DB_HOST", "db") %>
 
 development:
   <<: *default
@@ -35,7 +32,7 @@ test:
 # Instead, provide the password or a full connection URL as an environment
 # variable when you boot the app. For example:
 #
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#   DATABASE_URL="postgresql://myuser:mypass@localhost/somedatabase"
 #
 # If the connection URL is provided in the special DATABASE_URL environment
 # variable, Rails will automatically merge its configuration values on top of
@@ -50,6 +47,5 @@ test:
 #
 production:
   <<: *default
-  database: app_production
-  username: app
-  password: <%= ENV["APP_DATABASE_PASSWORD"] %>
+  # Render expects DATABASE_URL to be set in the environment.
+  url: <%= ENV["DATABASE_URL"] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,19 +18,19 @@ services:
     stdin_open: true
 
   db:
-    image: mysql:8.4.3
-    # m1はplatformを指定して、linux/amd64にエミュレートする指定をすることで正常に動く
-    platform: linux/amd64
-    # DBのレコードが日本語だと文字化けするので、utf8をセットする
-    command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+    image: postgres:16
+    # m1 は image によっては platform 指定が必要な場合があるため、必要に応じて指定する
+    # platform: linux/amd64
     volumes:
-      - mysql_data:/var/lib/mysql
+      - postgres_data:/var/lib/postgresql/data
     # 環境変数
     environment:
-      MYSQL_ROOT_PASSWORD: password
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: postgres
+      POSTGRES_DB: app_development
       TZ: "Asia/Tokyo"
     ports:
-      - "3306:3306"
+      - "5432:5432"
 
   redis:
     image: "redis:latest"
@@ -56,5 +56,5 @@ services:
 # コンテナを作り直したとしてもPC上に残るようにするために設定
 volumes:
   gem_data:
-  mysql_data:
+  postgres_data:
   redis_data:


### PR DESCRIPTION
対応するissue
---
Closes #162

概要
---
Render デプロイに向けて DB を MySQL から PostgreSQL に切り替えた。

エンドポイント
---
変更なし

UI の比較
----
なし

実装の詳細
----
- `config/database.yml` を PostgreSQL 用に更新し、production は `DATABASE_URL` を利用
- `docker-compose.yml` を PostgreSQL サービス/ボリューム構成へ変更
- `Gemfile` の DB ドライバを `pg` に変更

追加した Gem
---
- https://rubygems.org/gems/pg

備考
---
- 実行したコマンド: `docker compose exec web rails db:prepare`, `docker compose exec web rails db:seed_fu`
