### PR TITLE
Render本番向けのDockerfileとBlueprint設定を追加

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+FROM ruby:3.3.8-slim AS build
+
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    libpq-dev \
+    pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY Gemfile Gemfile.lock ./
+ENV BUNDLE_WITHOUT="development test" \
+    BUNDLE_DEPLOYMENT=1 \
+    BUNDLE_PATH=/bundle
+RUN bundle install
+
+COPY . .
+ENV RAILS_ENV=production \
+    SECRET_KEY_BASE_DUMMY=1
+RUN bundle exec rails assets:precompile
+
+FROM ruby:3.3.8-slim
+
+RUN apt-get update -qq \
+  && apt-get install -y --no-install-recommends \
+    libpq5 \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV RAILS_ENV=production \
+    BUNDLE_WITHOUT="development test" \
+    BUNDLE_DEPLOYMENT=1 \
+    BUNDLE_PATH=/bundle
+
+WORKDIR /app
+
+COPY --from=build /bundle /bundle
+COPY --from=build /app /app
+
+EXPOSE 3000
+
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,9 @@
+redis_url = ENV.fetch("REDIS_URL", "redis://redis:6379/0")
+
 Sidekiq.configure_server do |config|
-  config.redis = { url: 'redis://redis:6379' }
+  config.redis = { url: redis_url }
 end
 
 Sidekiq.configure_client do |config|
-  config.redis = { url: 'redis://redis:6379' }
+  config.redis = { url: redis_url }
 end

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,63 @@
+databases:
+  - name: kokushiex-db
+    plan: starter
+    databaseName: kokushiex
+    user: kokushiex
+    region: singapore
+
+services:
+  - type: redis
+    name: kokushiex-redis
+    plan: starter
+    region: singapore
+
+  - type: web
+    name: kokushiex-web
+    runtime: docker
+    region: singapore
+    plan: starter
+    dockerfilePath: Dockerfile.prod
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: kokushiex-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          name: kokushiex-redis
+          type: redis
+          property: connectionString
+      - key: SECRET_KEY_BASE
+        sync: false
+      - key: RAILS_ENV
+        value: production
+      - key: RACK_ENV
+        value: production
+      - key: RAILS_LOG_TO_STDOUT
+        value: "true"
+      - key: RAILS_SERVE_STATIC_FILES
+        value: "true"
+
+  - type: worker
+    name: kokushiex-worker
+    runtime: docker
+    region: singapore
+    plan: starter
+    dockerfilePath: Dockerfile.prod
+    dockerCommand: bundle exec sidekiq
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: kokushiex-db
+          property: connectionString
+      - key: REDIS_URL
+        fromService:
+          name: kokushiex-redis
+          type: redis
+          property: connectionString
+      - key: SECRET_KEY_BASE
+        sync: false
+      - key: RAILS_ENV
+        value: production
+      - key: RACK_ENV
+        value: production


### PR DESCRIPTION
対応するissue
---
なし

概要
---
Render本番向けのDockerfileとBlueprint設定を追加し、SidekiqのRedis接続を環境変数に対応させました。

エンドポイント
---
なし

UI の比較
----
なし

実装の詳細
----
- Dockerfile.prodを追加し、本番向けに依存関係とassets:precompileを実行
- render.yamlにPostgres/Redis/Web/Workerを定義しruntime: dockerなどを明示
- SidekiqのRedis接続をENV参照に変更

追加した Gem
---
なし

備考
---
テスト未実施（設定追加のみ）