### PR TITLE
[fix] reusable workflowのOIDC権限を付与

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -21,6 +21,9 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    permissions:
+      id-token: write
+      contents: read
     uses: ./.github/workflows/reusable-ecs-deploy.yml
     with:
       environment_name: production


### PR DESCRIPTION
 ## 対応するissue

  - なし

  ## 概要

  - Deploy Production ワークフローが reusable workflow 呼び出し時に失敗してい
    た問題を修正
  - 呼び出し元ジョブに OIDC 用の permissions を追加し、configure-aws-
    credentials が実行できるようにした

  ## エンドポイント

  - なし（CI/CD ワークフロー修正のため）

  ## UIの比較

  - なし

  ## 実装の詳細

  - 修正ファイル:
      - .github/workflows/deploy-prod.yml
  - 変更内容:
      - jobs.deploy.permissions を追加
          - id-token: write
          - contents: read
  - 背景:
      - エラー:
        The nested job 'deploy' is requesting 'id-token: write', but is only
        allowed 'id-token: none'.
      - reusable workflow (reusable-ecs-deploy.yml) 内で OIDC AssumeRole を行
        うため、呼び出し元でも id-token: write が必要

  ## 追加した Gem

  - なし

  ## 備考

  - 実行確認観点:
      - Actions > Deploy Production > Run workflow が起動可能
      - OIDC 認証ステップ (Configure AWS Credentials) が権限エラーなく通ること
  - ブランチ:
      - fix/github-actions-oidc-permission
  - コミット:
      - b03202b [fix] reusable workflowのOIDC権限を付与