### PR TITLE
[fix] ECS 1台構成でのデプロイ待機タイムアウトを解消

### DIFF
--- a/infra/terraform/ecs.tf
+++ b/infra/terraform/ecs.tf
@@ -195,10 +195,12 @@ resource "aws_ecs_task_definition" "worker" {
 }
 
 resource "aws_ecs_service" "web" {
-  name            = "${local.name_prefix}-web"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.web.arn
-  desired_count   = 1
+  name                               = "${local.name_prefix}-web"
+  cluster                            = aws_ecs_cluster.main.id
+  task_definition                    = aws_ecs_task_definition.web.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
 
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.ec2.name
@@ -224,10 +226,12 @@ resource "aws_ecs_service" "web" {
 }
 
 resource "aws_ecs_service" "worker" {
-  name            = "${local.name_prefix}-worker"
-  cluster         = aws_ecs_cluster.main.id
-  task_definition = aws_ecs_task_definition.worker.arn
-  desired_count   = 1
+  name                               = "${local.name_prefix}-worker"
+  cluster                            = aws_ecs_cluster.main.id
+  task_definition                    = aws_ecs_task_definition.worker.arn
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
 
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.ec2.name


### PR DESCRIPTION
  対応するissue
  ---
  Closes #119

  概要
  ---
  ECS on EC2（1台構成）でデプロイ時に `aws ecs wait services-stable` がタイム
  アウトする問題を修正しました。
  `web` / `worker` サービスのデプロイ設定を、単一インスタンスでも詰まらない値
  に明示しています。

  エンドポイント
  ---

  なし（インフラ設定のみ）

  UI の比較
  ----

  なし（UI変更なし）

  実装の詳細
  ----

  - `infra/terraform/ecs.tf` の `aws_ecs_service.web` /
  `aws_ecs_service.worker` に以下を追加
    - `deployment_minimum_healthy_percent = 0`
    - `deployment_maximum_percent = 100`
  - 1台構成時に旧タスク維持（min healthy 100%）で新タスクを配置できず、デプロ
  イが進行中のまま待機タイムアウトする状態を回避
  - Terraform 適用後、GitHub Actions の `Deploy Production` が成功することを確
  認済み

  追加した Gem
  ---

  なし

  備考
  ---

  - 実行コマンド
    - `AWS_PROFILE=kokushiex-prod terraform plan`
    - `AWS_PROFILE=kokushiex-prod terraform apply`
  - 適用結果: `Resources: 0 added, 2 changed, 0 destroyed`
  - 本番デプロイ（GitHub Actions）成功確認済み