### PR TITLE
[修正] 試験終了ボタンの回答保存と結果遷移を修正

### DIFF
--- a/app/controllers/examinations_controller.rb
+++ b/app/controllers/examinations_controller.rb
@@ -2,7 +2,7 @@ class ExaminationsController < ApplicationController
   before_action :authenticate_user!
 
   def show
-    @examination = current_user.examinations.find(params[:id])
+    @examination = current_user.examinations.includes(user_responses: :choice).find(params[:id])
     authorize @examination
     @score = @examination.score
     @test = @examination.test

--- a/app/controllers/user_responses_controller.rb
+++ b/app/controllers/user_responses_controller.rb
@@ -3,16 +3,22 @@ class UserResponsesController < ApplicationController
   before_action :ensure_guest_can_submit, only: :create
 
   def create # rubocop:disable Metrics/MethodLength
-    # rescue内でparams再取得を防ぐため、事前に変数に格納
-    test_id = sanitized_test_id
-    choice_ids = sanitized_choice_ids
+    test_id = nil
+    choice_ids = []
 
-    ActiveRecord::Base.transaction do
-      Examination.create_result!(user_id: current_user.id,
-                                 test_id:,
-                                 attempt_date: DateTime.current,
-                                 choice_ids:)
-      redirect_to dashboard_path, notice: '試験結果を保存しました'
+    begin
+      # rescue内でparams再取得を防ぐため、事前に変数に格納
+      test_id = sanitized_test_id
+      choice_ids = sanitized_choice_ids
+
+      # 途中失敗時にExaminationだけが残らないよう、rescueはtransactionの外で行う
+      examination = ActiveRecord::Base.transaction do
+        Examination.create_result!(user_id: current_user.id,
+                                   test_id:,
+                                   attempt_date: DateTime.current,
+                                   choice_ids:)
+      end
+      redirect_to examination_path(examination), notice: '試験結果を保存しました'
     rescue StandardError => e
       logger.error("試験結果の保存エラー: #{e.message}")
       @user_responses = choice_ids
@@ -31,11 +37,17 @@ class UserResponsesController < ApplicationController
   end
 
   def sanitized_choice_ids
+    # 未回答で終了した場合は空配列として扱い、0回答のまま採点する
     return [] if user_response_params[:choice_ids].blank?
 
-    user_response_params[:choice_ids]
-      .select { |id| id.to_s =~ /\A\d+\z/ }
-      .map(&:to_i)
+    # choice_idsが送信されている場合、不正値を空回答に変換せず改ざんとして失敗させる
+    raise Examination::InvalidChoiceError, 'Invalid choice IDs provided' unless numeric_choice_ids?
+
+    user_response_params[:choice_ids].map(&:to_i)
+  end
+
+  def numeric_choice_ids?
+    user_response_params[:choice_ids].all? { |id| id.to_s =~ /\A\d+\z/ }
   end
 
   def ensure_guest_can_submit

--- a/app/models/examination.rb
+++ b/app/models/examination.rb
@@ -32,13 +32,15 @@ class Examination < ApplicationRecord
 
   def self.create_result!(user_id:, test_id:, attempt_date:, choice_ids:)
     examination = Examination.create!(user_id:, test_id:, attempt_date:)
-    # 回答の保存
-    unless UserResponse.bulk_create_responses(examination, choice_ids)
+
+    # 未回答で終了した場合も0回答として採点するため、UserResponseは作成しない
+    if choice_ids.present? && !UserResponse.bulk_create_responses(examination, choice_ids)
       raise InvalidChoiceError, 'Invalid choice IDs provided'
     end
 
     # スコア計算
     Score::ScoreCalculator.new(examination).call
+    examination
   end
 
   private

--- a/app/models/user_response.rb
+++ b/app/models/user_response.rb
@@ -36,10 +36,9 @@ class UserResponse < ApplicationRecord
       return false
     end
 
-    choices = Choice.where(id: sanitized_ids)
-    if choices.size != sanitized_ids.size
-      missing_ids = sanitized_ids - choices.pluck(:id)
-      Rails.logger.error "Missing Choice IDs: #{missing_ids.join(', ')}"
+    valid_choice_ids = choice_ids_for_examination(examination, sanitized_ids)
+    if valid_choice_ids.size != sanitized_ids.size
+      log_invalid_choice_ids(examination, sanitized_ids - valid_choice_ids)
       return false
     end
 
@@ -86,5 +85,17 @@ class UserResponse < ApplicationRecord
                            .keys
     raise ArgumentError, "Duplicate Choice IDs detected: #{duplicates.join(', ')}" if duplicates.present?
   end
-  private_class_method :sanitize_choice_ids, :normalize_choice_ids, :ensure_no_duplicates!
+
+  def self.choice_ids_for_examination(examination, choice_ids)
+    # 直接POSTで別試験のchoice_idを混ぜられないよう、受験対象testに属する選択肢だけを許可する
+    Choice.joins(question: :test_session)
+          .where(id: choice_ids, test_sessions: { test_id: examination.test_id })
+          .pluck(:id)
+  end
+
+  def self.log_invalid_choice_ids(examination, choice_ids)
+    Rails.logger.error "Invalid Choice IDs for test #{examination.test_id}: #{choice_ids.join(', ')}"
+  end
+  private_class_method :sanitize_choice_ids, :normalize_choice_ids, :ensure_no_duplicates!,
+                       :choice_ids_for_examination, :log_invalid_choice_ids
 end

--- a/app/views/tests/show.html.erb
+++ b/app/views/tests/show.html.erb
@@ -1,5 +1,5 @@
-<%= form_with url: user_responses_path, method: :post do |f| %>
-  <%= hidden_field_tag :test_id, @test.id %>
+<%= form_with url: user_responses_path, method: :post, scope: :user_response do |f| %>
+  <%= f.hidden_field :test_id, value: @test.id %>
   <%= render 'question', question: @question %>
   <div class="text-center justify-center">
     <%= f.submit 'テストを終了する',

--- a/db/fixtures/production/05_pass_mark.rb
+++ b/db/fixtures/production/05_pass_mark.rb
@@ -15,4 +15,10 @@ PassMark.seed(:id, [
   { id: 9, test_id: 9, required_score: 168, required_practical_score: 43, total_score: 280 },
   # http://masamijk.net/seminar/fu-se-493.html
   { id: 10, test_id: 10, required_score: 167, required_practical_score: 41, total_score: 277 },
+  # https://www.mhlw.go.jp/general/sikaku/successlist/2026/siken08_09/about.html
+  { id: 11, test_id: 11, required_score: 167, required_practical_score: 41, total_score: 277 },
+  # https://www.mhlw.go.jp/general/sikaku/successlist/2025/siken08_09/about.html
+  { id: 12, test_id: 12, required_score: 164, required_practical_score: 40, total_score: 273 },
+  # https://www.mhlw.go.jp/general/sikaku/successlist/2024/siken08_09-2/about.html
+  { id: 13, test_id: 13, required_score: 168, required_practical_score: 43, total_score: 279 },
 ])

--- a/spec/models/examination_spec.rb
+++ b/spec/models/examination_spec.rb
@@ -44,5 +44,21 @@ RSpec.describe Examination do
       expect(UserResponse).to have_received(:bulk_create_responses).with(instance_of(described_class), choice_ids)
       expect(score_calculator_mock).to have_received(:call)
     end
+
+    it '作成したExaminationを返す' do
+      result = described_class.create_result!(**params)
+      expect(result).to be_a(described_class)
+      expect(result).to be_persisted
+    end
+
+    context 'choice_idsが空の場合' do
+      let(:choice_ids) { [] }
+
+      it 'UserResponseを作成せず、0回答としてScoreの処理を呼び出す' do
+        expect { described_class.create_result!(**params) }.to change(described_class, :count).by(1)
+        expect(UserResponse).not_to have_received(:bulk_create_responses)
+        expect(score_calculator_mock).to have_received(:call)
+      end
+    end
   end
 end

--- a/spec/models/user_response_spec.rb
+++ b/spec/models/user_response_spec.rb
@@ -23,7 +23,9 @@ require 'rails_helper'
 RSpec.describe UserResponse do
   describe '#bulk_create_responses' do
     let(:examination) { create(:examination) }
-    let(:choice_ids) { create_list(:choice, 3).map(&:id) }
+    let(:test_session) { create(:test_session, test: examination.test) }
+    let(:question) { create(:question, test_session:) }
+    let(:choice_ids) { create_list(:choice, 3, question:).map(&:id) }
 
     before do
       allow(Rails.logger).to receive(:error)
@@ -63,7 +65,21 @@ RSpec.describe UserResponse do
         missing_ids = [invalid_choice_id]
 
         described_class.bulk_create_responses(examination, choice_ids_with_invalid)
-        expect(Rails.logger).to have_received(:error).with("Missing Choice IDs: #{missing_ids.join(', ')}").once
+        expect(Rails.logger).to have_received(:error)
+          .with("Invalid Choice IDs for test #{examination.test_id}: #{missing_ids.join(', ')}").once
+      end
+    end
+
+    context '別試験のchoice_idが含まれる場合' do
+      it 'user_responseは作成されずログに出力される' do
+        other_test = create(:test)
+        other_test_session = create(:test_session, test: other_test)
+        other_question = create(:question, test_session: other_test_session)
+        other_choice = create(:choice, question: other_question)
+
+        expect(described_class.bulk_create_responses(examination, [other_choice.id])).to be false
+        expect(Rails.logger).to have_received(:error)
+          .with("Invalid Choice IDs for test #{examination.test_id}: #{other_choice.id}").once
       end
     end
 

--- a/spec/requests/user_responses_spec.rb
+++ b/spec/requests/user_responses_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe 'UserResponses' do
   describe 'POST /create' do
     let(:user) { create(:user) }
     let(:test) { create(:test) }
-    let(:choice_ids) { create_list(:choice, 3).map(&:id) }
+    let(:test_session) { create(:test_session, test:) }
+    let(:question) { create(:question, test_session:) }
+    let(:choice_ids) { create_list(:choice, 3, question:).map(&:id) }
+    let(:examination) { create(:examination, user:, test:) }
     let(:params) do
       {
         user_response: {
@@ -21,23 +24,66 @@ RSpec.describe 'UserResponses' do
 
       context '正常系' do
         before do
-          allow(Examination).to receive(:create_result!)
+          allow(Examination).to receive(:create_result!).and_return(examination)
         end
 
-        it 'user_responseが作成されリダイレクトされる' do
+        it '受験結果が作成され、答え合わせ画面にリダイレクトされる' do
           post(user_responses_path, params:)
-          expect(response).to redirect_to(dashboard_path)
+          expect(response).to redirect_to(examination_path(examination))
           expect(flash[:notice]).to eq '試験結果を保存しました'
+        end
+
+        it 'choice_idsが送信されない場合、未回答として空配列で採点する' do
+          unanswered_params = {
+            user_response: {
+              test_id: test.id
+            }
+          }
+
+          post(user_responses_path, params: unanswered_params)
+          expect(Examination).to have_received(:create_result!).with(
+            hash_including(test_id: test.id, choice_ids: [])
+          )
         end
       end
 
       context '異常系' do
-        before do
+        it 'newテンプレートがレンダリングされ、エラーメッセージが表示される' do
           allow(Examination).to receive(:create_result!).and_raise(StandardError)
+
+          post(user_responses_path, params:)
+          expect(response).to redirect_to(test_path(test.id))
+          expect(flash[:alert]).to eq '試験結果を保存できませんでした'
         end
 
-        it 'newテンプレートがレンダリングされ、エラーメッセージが表示される' do
+        it '別試験のchoice_idが送信された場合、受験結果を保存しない' do
+          other_test = create(:test)
+          other_test_session = create(:test_session, test: other_test)
+          other_question = create(:question, test_session: other_test_session)
+          other_choice = create(:choice, question: other_question)
+          invalid_params = {
+            user_response: {
+              test_id: test.id,
+              choice_ids: [other_choice.id.to_s]
+            }
+          }
+
+          expect do
+            post(user_responses_path, params: invalid_params)
+          end.not_to change(Examination, :count)
+          expect(response).to redirect_to(test_path(test.id))
+          expect(flash[:alert]).to eq '試験結果を保存できませんでした'
+        end
+
+        it '採点処理で例外が発生した場合、途中作成した受験結果と回答をロールバックする' do
+          allow_any_instance_of(Score::ScoreCalculator).to receive(:call).and_raise(StandardError)
+          examination_count = Examination.count
+          user_response_count = UserResponse.count
+
           post(user_responses_path, params:)
+
+          expect(Examination.count).to eq examination_count
+          expect(UserResponse.count).to eq user_response_count
           expect(response).to redirect_to(test_path(test.id))
           expect(flash[:alert]).to eq '試験結果を保存できませんでした'
         end
@@ -48,7 +94,7 @@ RSpec.describe 'UserResponses' do
           allow(Examination).to receive(:create_result!)
         end
 
-        it 'choice_idsに不正な文字列が含まれる場合、有効な整数IDのみがフィルタリングされる' do
+        it 'choice_idsに不正な文字列が含まれる場合、空回答として扱わず保存に失敗する' do
           invalid_params = {
             user_response: {
               test_id: test.id,
@@ -56,9 +102,9 @@ RSpec.describe 'UserResponses' do
             }
           }
           post(user_responses_path, params: invalid_params)
-          expect(Examination).to have_received(:create_result!).with(
-            hash_including(choice_ids: [1, 2, 4])
-          )
+          expect(Examination).not_to have_received(:create_result!)
+          expect(response).to redirect_to(test_path(test.id))
+          expect(flash[:alert]).to eq '試験結果を保存できませんでした'
         end
 
         it 'test_idが文字列で送信された場合でも整数に変換される' do


### PR DESCRIPTION
対応するissue
---
Closes #180

概要
---

試験終了ボタン押下時に回答保存・採点・答え合わせ画面遷移が正しく動作するよう修正しました。

主な原因は、試験画面の `test_id` 送信形式と `UserResponsesController` が期待する params 構造の不一致、採点後の遷移先が dashboard になっていたこと、未回答時や不正な `choice_ids` の扱いが曖昧だったことです。

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `POST /user_responses` | `user_responses#create` | 試験回答を保存し、採点後に答え合わせ画面へ遷移する |
| `GET /examinations/:id` | `examinations#show` | 採点結果と正誤表を表示する |

UI の比較
----

| 現状 | figma |
|:------:|:------:|
| なし | なし |

実装の詳細
----

- 試験画面の hidden field を `user_response[test_id]` として送信するよう修正しました
- `Examination.create_result!` が作成した `Examination` を返すようにしました
- 回答保存・採点成功後の遷移先を `dashboard` から `examinations#show` に変更しました
- 未回答で終了した場合は 0 回答として採点するよう明文化しました
- `choice_ids` に不正文字列が含まれる場合は空回答扱いにせず保存失敗にしました
- 別試験の `choice_id` を直接 POST しても保存できないよう、対象 test に属する選択肢だけを許可しました
- 保存・採点中に例外が発生した場合、途中作成された `Examination` / `UserResponse` が残らないよう transaction と rescue の位置を修正しました
- 結果画面で `UserResponse#choice` の N+1 が出ないよう `ExaminationsController#show` で eager load しました
- 第59回・第60回・第61回の `PassMark` seed を追加しました

追加した Gem
---

なし

備考
---

実行した確認コマンド:

```sh
docker-compose exec web bundle exec rspec spec/requests/user_responses_spec.rb spec/models/user_response_spec.rb spec/models/examination_spec.rb

docker-compose exec web bundle exec rubocop app/controllers/user_responses_controller.rb app/models/user_response.rb spec/requests/user_responses_spec.rb spec/models/user_response_spec.rb spec/models/examination_spec.rb

docker-compose exec web bundle exec rspec spec/requests/examinations_spec.rb

docker-compose exec web bundle exec rubocop app/controllers/examinations_controller.rb

docker-compose exec web bundle exec erblint app/views/tests/show.html.erb
```

seed 投入確認:

```sh
docker-compose exec web rails db:prepare:development
docker-compose exec web rails runner "puts PassMark.where(id: [11, 12, 13]).order(:id).pluck(:id, :test_id, :required_score, :required_practical_score, :total_score).inspect"
```

確認結果:

```rb
[[11, 11, 167, 41, 277], [12, 12, 164, 40, 273], [13, 13, 168, 43, 279]]
```
