### PR TITLE
[add] Googleログインを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'bootsnap', require: false
 gem 'devise', '>= 5.0.4'
 gem 'devise-i18n'
 gem 'omniauth'
+gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 
 # 認可

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,8 @@ GEM
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
     ast (2.4.2)
+    auth-sanitizer (0.2.0)
+      version_gem (~> 1.1, >= 1.1.9)
     base64 (0.3.0)
     bcrypt (3.1.22)
     benchmark (0.5.0)
@@ -163,6 +165,12 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
+    faraday (2.14.2)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     globalid (1.3.0)
       activesupport (>= 6.1)
     hashie (5.1.0)
@@ -183,6 +191,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.9.0)
+    jwt (3.2.0)
+      base64
     language_server-protocol (3.17.0.3)
     launchy (3.0.1)
       addressable (~> 2.8)
@@ -210,6 +220,10 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.7.5)
+    multi_xml (0.9.1)
+      bigdecimal (>= 3.1, < 5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.5.12)
       date
       net-protocol
@@ -226,11 +240,28 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
+    oauth2 (2.0.20)
+      auth-sanitizer (~> 0.1, >= 0.1.3)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0, >= 2.0.4)
+      version_gem (~> 1.1, >= 1.1.9)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
       logger
       rack (>= 2.2.3)
       rack-protection
+    omniauth-google-oauth2 (1.2.2)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
+    omniauth-oauth2 (1.9.0)
+      oauth2 (>= 2.0.2, < 3)
+      omniauth (~> 2.0)
     omniauth-rails_csrf_protection (2.0.1)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
@@ -378,6 +409,9 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     smart_properties (1.17.0)
+    snaky_hash (2.0.4)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -406,7 +440,9 @@ GEM
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
     uniform_notifier (1.16.0)
+    uri (1.1.1)
     useragent (0.16.11)
+    version_gem (1.1.10)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -454,6 +490,7 @@ DEPENDENCIES
   launchy
   letter_opener_web
   omniauth
+  omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg
   puma

--- a/README.md
+++ b/README.md
@@ -69,12 +69,57 @@ docker-compose exec web bin/dev
 
 ### 管理者ユーザー（開発環境）
 
-シードデータで作成される管理者アカウント：
+シードデータで作成される開発環境専用の管理者アカウント：
 
 ```
 Email: admin@example.com
 Password: admin123
 ```
+
+このアカウントは `db:prepare:development` で投入される開発用 seed です。本番環境には投入しないでください。
+
+## Google OAuth ログイン
+
+Google ログインをローカルまたは本番で有効にするには、Google Cloud Console で OAuth クライアントを作成します。
+
+1. OAuth consent screen を設定する
+   - アプリ名
+   - サポートメール
+   - プライバシーポリシー: `https://app.kokushiex.com/privacy_policy`
+   - 利用規約: `https://app.kokushiex.com/terms_of_use`
+2. Web application の OAuth クライアントを作成する
+3. 承認済みリダイレクト URI を登録する
+   - `http://localhost:3000/users/auth/google_oauth2/callback`
+   - `https://app.kokushiex.com/users/auth/google_oauth2/callback`
+
+Rails credentials には以下の形式で設定します。実値はコミットしないでください。
+
+```yaml
+google_oauth:
+  client_id: your-google-client-id
+  client_secret: your-google-client-secret
+```
+
+環境変数で設定する場合は、以下を使います。
+
+```bash
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+```
+
+credentials が空の場合のみ環境変数へ fallback します。client id と client secret の両方が設定されている場合だけ Google ログインが有効になります。scope は `email, profile` のみで、追加の Google API 権限は使用しません。
+
+credentials または環境変数を変更した場合は Rails を再起動してください。
+
+ローカルでの確認手順:
+
+```bash
+docker-compose up -d
+docker-compose exec web rails db:prepare:development
+docker-compose exec web bin/dev
+```
+
+`http://localhost:3000/users/sign_in` を開き、`admin@example.com` / `admin123` で通常ログインできることを確認します。Google credentials 未設定時は Google ボタンが表示されず、設定後に Rails を再起動すると `Googleでログイン` が表示されます。
 
 ## テスト
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  User.omniauth_providers.each do |provider|
+  %i[developer google_oauth2].each do |provider|
     define_method(provider) do
       handle_callback
     end
@@ -14,11 +14,12 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   private
 
   def handle_callback
-    result = Oauth::IdentityAuthenticator.new(
-      auth: request.env['omniauth.auth'],
-      current_user:
-    ).call
+    return redirect_oauth_failure unless callback_provider_matches?
 
+    redirect_oauth_result(authenticate_oauth_identity)
+  end
+
+  def redirect_oauth_result(result)
     if result.success?
       sign_in(:user, result.user)
       redirect_to after_sign_in_path_for(result.user), notice: result.message
@@ -27,7 +28,25 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  def redirect_oauth_failure
+    redirect_to failure_redirect_path, alert: t('oauth.identity_authenticator.failure')
+  end
+
   def failure_redirect_path
     user_signed_in? ? account_path : new_user_session_path
+  end
+
+  def callback_provider_matches?
+    auth_provider = request.env['omniauth.auth']&.provider.to_s
+    callback_provider = params[:action].to_s
+
+    auth_provider.present? && auth_provider == callback_provider
+  end
+
+  def authenticate_oauth_identity
+    Oauth::IdentityAuthenticator.new(
+      auth: request.env['omniauth.auth'],
+      current_user:
+    ).call
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,11 +35,22 @@ class User < ApplicationRecord
 
   has_many :examinations, dependent: :destroy
   has_many :user_identities, dependent: :destroy
+
+  def self.omniauth_provider_names
+    providers = []
+    providers << :developer if Rails.env.test?
+    providers.concat(Oauth::ProviderConfig.enabled_providers)
+  end
+
+  def self.omniauth_providers
+    omniauth_provider_names
+  end
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
-         :omniauthable, omniauth_providers: (Rails.env.test? ? [:developer] : [])
+         :omniauthable, omniauth_providers: omniauth_provider_names
 
   validates :username, presence: true, length: { maximum: 50 }
   validate :admin_restrictions

--- a/app/services/oauth/auth_hash_reader.rb
+++ b/app/services/oauth/auth_hash_reader.rb
@@ -25,6 +25,7 @@ module Oauth
     end
 
     def verified_email?
+      return google_verified_email? if provider == 'google_oauth2'
       return true if truthy?(info_value(:email_verified))
       return false unless raw_info_email_matches?
 
@@ -52,6 +53,10 @@ module Oauth
 
     def raw_info_email_matches?
       raw_info_value(:email).to_s.strip.downcase.presence == email
+    end
+
+    def google_verified_email?
+      raw_info_email_matches? && raw_info_value(:email_verified) == true
     end
 
     def fetch_value(object, key)

--- a/app/services/oauth/provider_config.rb
+++ b/app/services/oauth/provider_config.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Oauth
+  class ProviderConfig
+    GOOGLE_PROVIDER = :google_oauth2
+    GOOGLE_CLIENT_ID_ENV = 'GOOGLE_CLIENT_ID'
+    GOOGLE_CLIENT_SECRET_ENV = 'GOOGLE_CLIENT_SECRET'
+
+    class << self
+      def google_client_id
+        memoized(:@google_client_id) { configured_value(:client_id, GOOGLE_CLIENT_ID_ENV) }
+      end
+
+      def google_client_secret
+        memoized(:@google_client_secret) { configured_value(:client_secret, GOOGLE_CLIENT_SECRET_ENV) }
+      end
+
+      def google_enabled?
+        google_client_id.present? && google_client_secret.present?
+      end
+
+      def enabled_providers
+        google_enabled? ? [GOOGLE_PROVIDER] : []
+      end
+
+      def reset!
+        remove_instance_variable(:@google_client_id) if instance_variable_defined?(:@google_client_id)
+        remove_instance_variable(:@google_client_secret) if instance_variable_defined?(:@google_client_secret)
+      end
+
+      private
+
+      def memoized(variable_name)
+        return instance_variable_get(variable_name) if instance_variable_defined?(variable_name)
+
+        instance_variable_set(variable_name, yield)
+      end
+
+      def configured_value(credentials_key, env_key)
+        credentials_value = Rails.application.credentials.dig(:google_oauth, credentials_key)
+        credentials_value.to_s.presence || ENV[env_key].to_s.presence
+      end
+    end
+  end
+end

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -2,7 +2,6 @@
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
     <h2 class="mt-6 text-center text-3xl font-bold text-gray-900"><%= t('devise.registrations.new.title') %></h2>
   </div>
-
   <%= form_with(model: resource, as: resource_name, url: registration_path(resource_name),
                 method: :post, local: true, html: { class: 'mt-8 space-y-6 sm:mx-auto sm:w-full sm:max-w-md' }) do |f| %>
     <%= render 'devise/shared/error_messages', resource: %>
@@ -54,6 +53,9 @@
       </div>
     </div>
   <% end %>
+
+  <%= render 'users/shared/oauth_buttons', mode: :sign_up %>
+
   <div class="m-5">
     <p class="text-center text-gray-900">
       すでにアカウントをお持ちですか？<%= link_to 'ログイン', new_user_session_path, class: 'text-sky-500 hover:text-orange-300' %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,5 +1,4 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
-
   <%= form_with(model: resource, as: resource_name, url: user_session_path,
                 method: :post, local: true, html: { class: 'mt-8 space-y-6 sm:mx-auto sm:w-full sm:max-w-md' }) do |f| %>
     <%= render 'devise/shared/error_messages', resource: %>
@@ -39,4 +38,6 @@
       パスワードを忘れた場合は<%= link_to 'こちら', new_password_path(resource_name), class: 'text-sky-500 hover:text-orange-300' %>
     </p>
   </div>
+
+  <%= render 'users/shared/oauth_buttons', mode: :sign_in %>
 </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -17,10 +17,3 @@
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
   <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name) %><br>
 <% end %>
-
-<%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)),
-                  omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br>
-  <% end %>
-<% end %>

--- a/app/views/users/shared/_oauth_buttons.html.erb
+++ b/app/views/users/shared/_oauth_buttons.html.erb
@@ -1,0 +1,35 @@
+<% (User.omniauth_providers - [:developer]).select { |provider| provider == :google_oauth2 }.tap do |providers| %>
+  <% if providers.present? %>
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <div class="relative my-6">
+        <div class="absolute inset-0 flex items-center" aria-hidden="true">
+          <div class="w-full border-t border-gray-300"></div>
+        </div>
+        <div class="relative flex justify-center">
+          <span class="bg-white px-3 text-sm text-gray-500"><%= t('devise.shared.oauth_buttons.separator') %></span>
+        </div>
+      </div>
+
+      <div class="space-y-3">
+        <% providers.each do |provider| %>
+          <%= button_to public_send(:"#{resource_name}_#{provider}_omniauth_authorize_path"),
+                        method: :post,
+                        form: { data: { turbo: false } },
+                        class: [
+                          'flex w-full items-center justify-center gap-3 rounded-md border border-gray-300 bg-white',
+                          'px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50',
+                          'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2'
+                        ].join(' ') do %>
+            <svg class="h-5 w-5" viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+              <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.58 2.68-3.9 2.68-6.62z" />
+              <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.33-1.58-5.04-3.72H.94v2.34A9 9 0 0 0 9 18z" />
+              <path fill="#FBBC05" d="M3.96 10.7A5.4 5.4 0 0 1 3.68 9c0-.6.1-1.18.28-1.7V4.96H.94A9 9 0 0 0 0 9c0 1.45.35 2.82.94 4.04l3.02-2.34z" />
+              <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.34l2.58-2.58A8.66 8.66 0 0 0 9 0 9 9 0 0 0 .94 4.96L3.96 7.3C4.67 5.16 6.66 3.58 9 3.58z" />
+            </svg>
+            <span><%= t("devise.shared.oauth_buttons.google.#{mode}") %></span>
+          <% end %>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,6 +8,8 @@
 #
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
+require Rails.root.join('app/services/oauth/provider_config')
+
 Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
@@ -276,6 +278,12 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  if Oauth::ProviderConfig.google_enabled?
+    config.omniauth :google_oauth2,
+                    Oauth::ProviderConfig.google_client_id,
+                    Oauth::ProviderConfig.google_client_secret,
+                    scope: 'email,profile'
+  end
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -136,8 +136,12 @@ ja:
         didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
         forgot_your_password: パスワードを忘れましたか？
         sign_in: ログイン
-        sign_in_with_provider: "%{provider}でログイン"
         sign_up: アカウント登録
+      oauth_buttons:
+        google:
+          sign_in: Googleでログイン
+          sign_up: Googleで登録
+        separator: または
       minimum_password_length: "（%{count}字以上）"
     unlocks:
       new:

--- a/spec/fixtures/development_seed_users_spec.rb
+++ b/spec/fixtures/development_seed_users_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'development seed users' do
+  def parse_seed_value(string:, boolean:, integer:)
+    return boolean == 'true' if boolean
+    return integer.to_i if integer
+
+    string
+  end
+
+  def parse_seed_row(row)
+    row.scan(/(\w+):\s*(?:'([^']*)'|(true|false)|(\d+))/).each_with_object({}) do |match, hash|
+      key, string, boolean, integer = match
+      hash[key.to_sym] = parse_seed_value(string:, boolean:, integer:)
+    end
+  end
+
+  def development_user_seed_rows
+    source = Rails.root.join('db/fixtures/development/01_user.rb').read
+    source.scan(/\{[^{}]+\}/).map { |row| parse_seed_row(row) }
+  end
+
+  it '開発用fixtureに管理者ログイン確認用ユーザーが定義されている' do
+    admin = development_user_seed_rows.find { |row| row[:email] == 'admin@example.com' }
+
+    expect(admin).to include(
+      email: 'admin@example.com',
+      password: 'admin123',
+      admin: true
+    )
+  end
+
+  it 'production fixturesにUser.seedを含めない' do
+    production_sources = Rails.root.glob('db/fixtures/production/**/*.rb').map(&:read)
+
+    expect(production_sources).not_to include(a_string_matching(/User\.seed/))
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -30,6 +30,52 @@
 require 'rails_helper'
 
 RSpec.describe User do
+  describe '.omniauth_providers' do
+    it 'test環境ではdeveloper providerを維持する' do
+      allow(Oauth::ProviderConfig).to receive(:enabled_providers).and_return([])
+
+      expect(described_class.omniauth_providers).to eq [:developer]
+    end
+
+    it 'Googleが有効な場合はgoogle_oauth2を含める' do
+      allow(Oauth::ProviderConfig).to receive(:enabled_providers).and_return([:google_oauth2])
+
+      expect(described_class.omniauth_providers).to contain_exactly(:developer, :google_oauth2)
+    end
+
+    it 'Googleが無効な場合はgoogle_oauth2を含めない' do
+      allow(Oauth::ProviderConfig).to receive(:enabled_providers).and_return([])
+
+      expect(described_class.omniauth_providers).not_to include(:google_oauth2)
+    end
+  end
+
+  describe 'Devise OmniAuth provider設定' do
+    let(:devise_initializer) { Rails.root.join('config/initializers/devise.rb') }
+
+    it 'Googleが有効な場合はDeviseにもgoogle_oauth2を登録する' do
+      with_restored_devise_omniauth_configs do
+        with_google_oauth_credentials do
+          Devise.omniauth_configs.clear
+          load devise_initializer
+
+          expect(Devise.omniauth_configs.keys).to include(:google_oauth2)
+        end
+      end
+    end
+
+    it 'Googleが無効な場合はDeviseにgoogle_oauth2を登録しない' do
+      with_restored_devise_omniauth_configs do
+        with_google_oauth_credentials(client_id: nil, client_secret: nil) do
+          Devise.omniauth_configs.clear
+          load devise_initializer
+
+          expect(Devise.omniauth_configs.keys).not_to include(:google_oauth2)
+        end
+      end
+    end
+  end
+
   describe 'indexes' do
     it 'usernameのindexは重複を許可する' do
       index = ActiveRecord::Base.connection.indexes(:users).find { |i| i.name == 'index_users_on_username' }

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -1,14 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Users::omniauth_callbacks' do
-  before do
+  around do |example|
+    original_test_mode = OmniAuth.config.test_mode
+    original_developer_auth = OmniAuth.config.mock_auth[:developer]
+    original_google_auth = OmniAuth.config.mock_auth[:google_oauth2]
+
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:developer] = auth
-  end
 
-  after do
-    OmniAuth.config.mock_auth[:developer] = nil
-    OmniAuth.config.test_mode = false
+    example.run
+  ensure
+    OmniAuth.config.mock_auth[:developer] = original_developer_auth
+    OmniAuth.config.mock_auth[:google_oauth2] = original_google_auth
+    OmniAuth.config.test_mode = original_test_mode
   end
 
   let(:auth) do
@@ -19,14 +24,17 @@ RSpec.describe 'Users::omniauth_callbacks' do
     attributes = default_auth_attributes.merge(overrides)
 
     OmniAuth::AuthHash.new(provider: attributes[:provider], uid: attributes[:uid],
-                           info: attributes.slice(:email, :email_verified, :name, :image))
+                           info: attributes.slice(:email, :email_verified, :name, :image),
+                           credentials: attributes[:credentials],
+                           extra: { raw_info: attributes[:raw_info] })
   end
 
   def default_auth_attributes
     {
       provider: 'developer', uid: 'uid-123',
       email: 'user@example.com', email_verified: true,
-      name: 'OAuth User', image: 'https://example.com/avatar.png'
+      name: 'OAuth User', image: 'https://example.com/avatar.png',
+      credentials: nil, raw_info: nil
     }
   end
 
@@ -239,6 +247,112 @@ RSpec.describe 'Users::omniauth_callbacks' do
         expect(response).to redirect_to(new_user_session_path)
         expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.unverified_email')
         expect(controller.current_user).to be_nil
+      end
+    end
+  end
+
+  describe 'GET /users/auth/google_oauth2/callback' do
+    around do |example|
+      with_google_oauth_routes(enabled: true) { example.run }
+    end
+
+    before do
+      OmniAuth.config.mock_auth[:google_oauth2] = auth
+    end
+
+    def google_callback
+      get user_google_oauth2_omniauth_callback_path, env: { 'omniauth.auth' => auth }
+    end
+
+    let(:auth) do
+      auth_hash(
+        provider: 'google_oauth2',
+        uid: 'google-uid-123',
+        email: 'google-user@example.com',
+        email_verified: nil,
+        raw_info: { email: 'google-user@example.com', email_verified: true },
+        credentials: {
+          token: 'access-token',
+          refresh_token: 'refresh-token'
+        }
+      )
+    end
+
+    it 'raw_info.email_verifiedがtrueでemailが一致する場合のみ新規ユーザーを作成してログインする' do
+      expect do
+        google_callback
+      end.to change(User, :count).by(1).and change(UserIdentity, :count).by(1)
+
+      identity = UserIdentity.find_by(provider: 'google_oauth2', uid: 'google-uid-123')
+      aggregate_failures do
+        expect(response).to redirect_to(root_path)
+        expect(controller.current_user).to eq identity.user
+        expect(identity.email).to eq 'google-user@example.com'
+      end
+    end
+
+    it 'tokenやraw_infoをUserIdentityへ保存しない' do
+      google_callback
+
+      identity = UserIdentity.find_by!(provider: 'google_oauth2', uid: 'google-uid-123')
+      aggregate_failures do
+        expect(identity.attributes).not_to include('token')
+        expect(identity.attributes).not_to include('refresh_token')
+        expect(identity.attributes).not_to include('raw_info')
+      end
+    end
+
+    context 'raw_info.email_verifiedがfalseの場合' do
+      let(:auth) do
+        auth_hash(
+          provider: 'google_oauth2',
+          uid: 'google-uid-123',
+          email: 'google-user@example.com',
+          email_verified: true,
+          raw_info: { email: 'google-user@example.com', email_verified: false }
+        )
+      end
+
+      it 'info.email_verifiedがtrueでも失敗する' do
+        expect do
+          google_callback
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.unverified_email')
+      end
+    end
+
+    context 'raw_info.emailとinfo.emailが一致しない場合' do
+      let(:auth) do
+        auth_hash(
+          provider: 'google_oauth2',
+          uid: 'google-uid-123',
+          email: 'google-user@example.com',
+          raw_info: { email: 'other@example.com', email_verified: true }
+        )
+      end
+
+      it '失敗する' do
+        expect do
+          google_callback
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.unverified_email')
+      end
+    end
+
+    context 'callback providerとauth.providerが一致しない場合' do
+      let(:auth) { auth_hash(provider: 'developer', uid: 'developer-uid') }
+
+      it 'identityを作成せず失敗する' do
+        expect do
+          google_callback
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.failure')
       end
     end
   end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -3,10 +3,40 @@ require 'rails_helper'
 RSpec.describe 'Users::registrations' do
   let(:user) { create(:user) }
 
+  def parsed_response
+    Nokogiri::HTML(response.body)
+  end
+
   describe 'GET /users/sign_up' do
     it 'ユーザー登録画面が表示される' do
       get new_user_registration_path
       expect(response).to have_http_status(:success)
+    end
+
+    it 'Googleが無効な場合はGoogle登録ボタンを表示しない' do
+      with_google_oauth_routes(enabled: false) do
+        get new_user_registration_path
+
+        expect(response.body).not_to include('Googleで登録')
+      end
+    end
+
+    it 'Googleが有効な場合はPOSTのGoogle登録ボタンを表示する' do
+      with_google_oauth_routes(enabled: true) do
+        get new_user_registration_path
+        google_form = parsed_response.at_css(
+          'form[action="/users/auth/google_oauth2"][method="post"][data-turbo="false"]'
+        )
+
+        aggregate_failures do
+          expect(response.body).to include('Googleで登録')
+          expect(google_form).to be_present
+          expect(google_form.at_css('svg')).to be_present
+          expect(response.body.index('action="/users"'))
+            .to be < response.body.index('action="/users/auth/google_oauth2"')
+          expect(response.body).not_to include('href="/users/auth/google_oauth2"')
+        end
+      end
     end
   end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe 'Users::sessions' do
       .find { |header| header.start_with?("#{name}=") }
   end
 
+  def parsed_response
+    Nokogiri::HTML(response.body)
+  end
+
   describe 'POST /users/sign_in' do
     let(:user) do
       User.create(username: 'testuser', email: 'testuser@example.com', password: 'password',
@@ -75,6 +79,58 @@ RSpec.describe 'Users::sessions' do
         post user_session_path, params: invalid_login_params
         expect(response).to render_template(:new)
         expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+  end
+
+  describe 'seed管理者相当の通常ログイン' do
+    let(:seed_admin_password) { 'admin123' }
+    let!(:seed_admin) do
+      create(:user, :admin, email: 'admin@example.com', password: seed_admin_password,
+                            password_confirmation: seed_admin_password)
+    end
+
+    before do
+      Rack::Attack.cache.store.clear
+    end
+
+    it 'Googleが無効でもメールアドレスとパスワードでログインできる' do
+      with_google_oauth_routes(enabled: false) do
+        get new_user_session_path
+
+        aggregate_failures do
+          expect(response.body).to include('name="user[email]"')
+          expect(response.body).to include('name="user[password]"')
+          expect(response.body).to include('value="ログイン"')
+          expect(response.body).not_to include('Googleでログイン')
+        end
+
+        post user_session_path, params: { user: { email: seed_admin.email, password: seed_admin_password } }
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    it 'Googleが有効でOAuthボタンが表示されても通常ログインできる' do
+      with_google_oauth_routes(enabled: true) do
+        get new_user_session_path
+        google_form = parsed_response.at_css(
+          'form[action="/users/auth/google_oauth2"][method="post"][data-turbo="false"]'
+        )
+
+        aggregate_failures do
+          expect(response.body).to include('Googleでログイン')
+          expect(google_form).to be_present
+          expect(google_form.at_css('svg')).to be_present
+          expect(response.body.index('action="/users/sign_in"'))
+            .to be < response.body.index('action="/users/auth/google_oauth2"')
+          expect(response.body).to include('name="user[email]"')
+          expect(response.body).to include('name="user[password]"')
+          expect(response.body).to include('value="ログイン"')
+          expect(response.body).not_to include('href="/users/auth/google_oauth2"')
+        end
+
+        post user_session_path, params: { user: { email: seed_admin.email, password: seed_admin_password } }
+        expect(response).to redirect_to(dashboard_path)
       end
     end
   end

--- a/spec/services/oauth/provider_config_spec.rb
+++ b/spec/services/oauth/provider_config_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Oauth::ProviderConfig do
+  around do |example|
+    original_client_id = ENV.fetch('GOOGLE_CLIENT_ID', nil)
+    original_client_secret = ENV.fetch('GOOGLE_CLIENT_SECRET', nil)
+    ENV.delete('GOOGLE_CLIENT_ID')
+    ENV.delete('GOOGLE_CLIENT_SECRET')
+    described_class.reset!
+
+    example.run
+  ensure
+    original_client_id.nil? ? ENV.delete('GOOGLE_CLIENT_ID') : ENV['GOOGLE_CLIENT_ID'] = original_client_id
+    if original_client_secret.nil?
+      ENV.delete('GOOGLE_CLIENT_SECRET')
+    else
+      ENV['GOOGLE_CLIENT_SECRET'] = original_client_secret
+    end
+    described_class.reset!
+  end
+
+  def stub_google_credentials(client_id:, client_secret:)
+    described_class.reset!
+    allow(Rails.application.credentials).to receive(:dig).and_call_original
+    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_id).and_return(client_id)
+    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_secret).and_return(client_secret)
+  end
+
+  describe '.google_enabled?' do
+    it 'client idとsecretが両方ある場合にtrueを返す' do
+      stub_google_credentials(client_id: 'credential-id', client_secret: 'credential-secret')
+
+      expect(described_class).to be_google_enabled
+      expect(described_class.enabled_providers).to eq [:google_oauth2]
+    end
+
+    it 'client idのみの場合にfalseを返す' do
+      stub_google_credentials(client_id: 'credential-id', client_secret: nil)
+
+      expect(described_class).not_to be_google_enabled
+      expect(described_class.enabled_providers).to be_empty
+    end
+
+    it 'client secretのみの場合にfalseを返す' do
+      stub_google_credentials(client_id: nil, client_secret: 'credential-secret')
+
+      expect(described_class).not_to be_google_enabled
+      expect(described_class.enabled_providers).to be_empty
+    end
+
+    it 'blankは未設定として扱う' do
+      stub_google_credentials(client_id: ' ', client_secret: '')
+
+      expect(described_class).not_to be_google_enabled
+      expect(described_class.enabled_providers).to be_empty
+    end
+
+    it 'credentialsをENVより優先する' do
+      stub_google_credentials(client_id: 'credential-id', client_secret: 'credential-secret')
+      ENV['GOOGLE_CLIENT_ID'] = 'env-id'
+      ENV['GOOGLE_CLIENT_SECRET'] = 'env-secret'
+
+      expect(described_class.google_client_id).to eq 'credential-id'
+      expect(described_class.google_client_secret).to eq 'credential-secret'
+    end
+
+    it 'credentialsがblankの場合はENVへfallbackする' do
+      stub_google_credentials(client_id: ' ', client_secret: nil)
+      ENV['GOOGLE_CLIENT_ID'] = 'env-id'
+      ENV['GOOGLE_CLIENT_SECRET'] = 'env-secret'
+
+      expect(described_class).to be_google_enabled
+      expect(described_class.google_client_id).to eq 'env-id'
+      expect(described_class.google_client_secret).to eq 'env-secret'
+    end
+  end
+end

--- a/spec/support/oauth_test_helpers.rb
+++ b/spec/support/oauth_test_helpers.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module OauthTestHelpers
+  GOOGLE_CLIENT_ID = 'google-client-id'
+  GOOGLE_CLIENT_SECRET = 'google-client-secret'
+
+  def with_google_oauth_routes(enabled: true)
+    original_enabled_providers = Oauth::ProviderConfig.singleton_class.instance_method(:enabled_providers)
+    replace_enabled_providers(enabled ? [:google_oauth2] : [])
+    Rails.application.reload_routes!
+
+    yield
+  ensure
+    restore_enabled_providers(original_enabled_providers)
+    Rails.application.reload_routes!
+  end
+
+  def with_google_oauth_credentials(client_id: GOOGLE_CLIENT_ID, client_secret: GOOGLE_CLIENT_SECRET,
+                                    env_client_id: nil, env_client_secret: nil)
+    original_env = google_oauth_env
+    set_google_oauth_env(client_id: env_client_id, client_secret: env_client_secret)
+    Oauth::ProviderConfig.reset!
+
+    stub_google_oauth_credentials(client_id:, client_secret:)
+
+    yield
+  ensure
+    set_google_oauth_env(**original_env)
+    Oauth::ProviderConfig.reset!
+  end
+
+  def with_restored_devise_omniauth_configs
+    original_configs = Devise.omniauth_configs.dup
+
+    yield
+  ensure
+    Devise.omniauth_configs.clear
+    Devise.omniauth_configs.merge!(original_configs)
+  end
+
+  private
+
+  def replace_enabled_providers(providers)
+    Oauth::ProviderConfig.define_singleton_method(:enabled_providers) { providers }
+  end
+
+  def restore_enabled_providers(original_enabled_providers)
+    Oauth::ProviderConfig.singleton_class.define_method(:enabled_providers, original_enabled_providers)
+  end
+
+  def google_oauth_env
+    {
+      client_id: ENV.fetch('GOOGLE_CLIENT_ID', nil),
+      client_secret: ENV.fetch('GOOGLE_CLIENT_SECRET', nil)
+    }
+  end
+
+  def set_google_oauth_env(client_id:, client_secret:)
+    set_env('GOOGLE_CLIENT_ID', client_id)
+    set_env('GOOGLE_CLIENT_SECRET', client_secret)
+  end
+
+  def stub_google_oauth_credentials(client_id:, client_secret:)
+    allow(Rails.application.credentials).to receive(:dig).and_call_original
+    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_id).and_return(client_id)
+    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_secret).and_return(client_secret)
+  end
+
+  def set_env(key, value)
+    value.nil? ? ENV.delete(key) : ENV[key] = value
+  end
+end
+
+RSpec.configure do |config|
+  config.include OauthTestHelpers
+end


### PR DESCRIPTION
対応するissue
---
Closes #185

概要
---

Google OAuth によるログイン導線を追加しました。

通常のメールアドレス/パスワードログインは維持しつつ、Google OAuth のクライアント ID とシークレットが設定されている場合のみ、ログイン画面・登録画面に Google ボタンを表示します。未設定時は既存の通常ログインだけが表示されます。

このセッションではローカル環境で Google Cloud の OAuth クライアントを作成し、実際に Google 認証できることまで確認しました。Google Cloud 側の本番運用に向けた設定方針も整理し、サポートメールには個人アドレスではなくサービス用の `kokushiex.support@gmail.com` を使う方針にしました。

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | --- | --- |
| `GET /users/sign_in` | `devise/sessions#new` | 通常ログインフォームと Google ログインボタンを表示する |
| `POST /users/auth/google_oauth2` | `users/omniauth_callbacks#passthru` | Google OAuth 認可リクエストを開始する |
| `GET /users/auth/google_oauth2/callback` | `users/omniauth_callbacks#google_oauth2` | Google OAuth の callback を処理してログイン/ユーザー作成する |
| `GET /users/sign_up` | `devise/registrations#new` | 通常登録フォームと Google 登録ボタンを表示する |

UI の比較
----

| 現状 | figma |
|:------:|:------:|
| Google OAuth 有効時、通常ログインフォームの下に区切り線と `Googleでログイン` ボタンを表示します。Google アイコン付きのボタンを追加しています。<img width="1289" height="657" alt="スクリーンショット 2026-06-07 19 22 57" src="https://github.com/user-attachments/assets/1de2d302-1331-4239-b8d2-28b1c3017a57" /> | なし |

実装の詳細
----

- `omniauth-google-oauth2` を追加しました。
- Google OAuth の有効/無効判定を `Oauth::ProviderConfig` に切り出しました。
- Google OAuth credentials は Rails credentials を優先し、未設定の場合のみ環境変数へ fallback します。
  - `Rails.application.credentials.dig(:google_oauth, :client_id)`
  - `Rails.application.credentials.dig(:google_oauth, :client_secret)`
  - `GOOGLE_CLIENT_ID`
  - `GOOGLE_CLIENT_SECRET`
- client id と client secret の両方が設定されている場合のみ `google_oauth2` provider を有効化します。
- Devise 初期化時に Google OAuth が有効な場合だけ `config.omniauth :google_oauth2` を登録します。
- test 環境の `developer` provider は維持し、Google provider と分離しました。
- OAuth callback では callback action と `omniauth.auth.provider` が一致することを確認し、不一致時は identity を作成せず失敗扱いにします。
- Google OAuth では `raw_info.email_verified == true` かつ `raw_info.email` と `info.email` が一致する場合のみ verified email として扱います。
- access token / refresh token / raw_info は `UserIdentity` に保存しないことを request spec で担保しました。
- ログイン画面・登録画面に Google ボタン用 partial を追加しました。
- 既存の Devise shared links から汎用 OmniAuth ボタン表示を外し、Google ボタン表示の責務を新 partial に集約しました。
- 通常ログインフォームは Google ログインより上に配置し、既存のメール/パスワードログイン導線を優先表示します。
- Google の認証が未設定の場合は Google ボタンを表示しません。
- README に Google OAuth の設定手順、redirect URI、credentials/ENV の設定方法、ローカル検証手順を追記しました。
- 開発用 seed 管理者 `admin@example.com` / `admin123` で通常ログインできることを request spec と seed fixture spec で確認しています。
- 開発用 seed 管理者は本番 fixtures に含めないことを spec で確認しています。

Google Cloud で設定・確認したこと
----

- OAuth consent screen / Google Auth Platform の対象は本番想定では `外部` としました。
- OAuth scope は次の最小構成にしました。
  - `openid`
  - `.../auth/userinfo.email`
  - `.../auth/userinfo.profile`
- BigQuery / Cloud Storage / Cloud Platform など追加 API scope は選択していません。
- OAuth クライアントの種類は `ウェブ アプリケーション` にしました。
- 承認済みリダイレクト URI は以下を想定しています。
  - `http://localhost:3000/users/auth/google_oauth2/callback`
  - `https://app.kokushiex.com/users/auth/google_oauth2/callback`
- Rails + OmniAuth の server-side OAuth flow なので、承認済み JavaScript 生成元は必須ではないと整理しました。
- アプリドメインは以下を想定しています。
  - ホームページ: `https://app.kokushiex.com`
  - プライバシーポリシー: `https://app.kokushiex.com/privacy_policy`
  - 利用規約: `https://app.kokushiex.com/terms_of_use`
- 承認済みドメインは `kokushiex.com` を使う想定です。
- ローカル `.env` に `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` を設定し、コンテナ再起動後に Google 認証できることを確認しました。

サポートメール・運用メモ
----

- 本番運用向けのサポートメールとして `kokushiex.support@gmail.com` を新規作成しました。
- Google Cloud の IAM に `kokushiex.support@gmail.com` を追加し、対象プロジェクトへアクセスできるようにしました。
- OAuth consent screen のユーザーサポートメールとして `kokushiex.support@gmail.com` を選択できることを確認しました。
- Google Workspace / Zoho Mail / Cloudflare Email Routing も検討しました。
- Google Workspace は有料のため、初期運用では無料の Gmail アカウントをサービス用サポートアドレスとして使う方針にしました。
- Cloudflare Email Routing は受信転送には使えますが、`support@kokushiex.com` として返信するには別途送信用メールサービスが必要と整理しました。
- 将来 `support@kokushiex.com` を独自ドメインメールとして運用する場合は、Google Workspace / Zoho Mail などへ移行して OAuth consent screen のサポートメールを差し替える想定です。

追加した Gem
---

- [omniauth-google-oauth2](https://github.com/zquestz/omniauth-google-oauth2)

備考
---

検証コマンド:

```bash
docker-compose exec web bundle exec rspec
docker-compose exec web bundle exec rubocop
docker-compose exec web bundle exec erblint --lint-all
```

検証結果:

```text
RSpec: 223 examples, 0 failures, 5 pending
RuboCop: 108 files inspected, no offenses detected
ERB lint: No errors were found in ERB files
```

`erblint` 実行時に、実行ファイル名が `erb_lint` へ変更された旨と `.erb-lint.yml` のリネーム警告が出ていますが、今回の変更とは別件で lint エラーはありません。

機密情報について:

- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` の実値は `.env` に設定しています。
- `.env` は git 管理外で、この PR には含めていません。
