### PR TITLE
[add] LINEログインを追加 Closes #186

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'devise', '>= 5.0.4'
 gem 'devise-i18n'
 gem 'omniauth'
 gem 'omniauth-google-oauth2'
+gem 'omniauth-line-v2'
 gem 'omniauth-rails_csrf_protection'
 
 # 認可

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,9 @@ GEM
       oauth2 (~> 2.0)
       omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.8)
+    omniauth-line-v2 (2.0.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
@@ -491,6 +494,7 @@ DEPENDENCIES
   letter_opener_web
   omniauth
   omniauth-google-oauth2
+  omniauth-line-v2
   omniauth-rails_csrf_protection
   pg
   puma

--- a/README.md
+++ b/README.md
@@ -111,7 +111,47 @@ credentials が空の場合のみ環境変数へ fallback します。client id 
 
 credentials または環境変数を変更した場合は Rails を再起動してください。
 
+## LINE Login
+
+LINE ログインは `omniauth-line-v2` で OmniAuth provider `line` として扱います。ローカルまたは本番で有効にするには、LINE Developers Console で LINE Login channel を作成します。
+
+1. LINE Developers Console で LINE Login channel を作成する
+2. App types で Web app を有効にする
+3. Callback URL を登録する
+   - `http://localhost:3000/users/auth/line/callback`
+   - `https://app.kokushiex.com/users/auth/line/callback`
+4. scope は `profile openid email` を使用する
+5. email を取得する場合は Email address permission を申請・承認する
+
+Rails credentials には以下の key で設定します。実値はコミットしないでください。
+
+```yaml
+line_oauth:
+  client_id:
+  client_secret:
+```
+
+環境変数で設定する場合は、以下を使います。
+
+```bash
+LINE_CLIENT_ID=
+LINE_CLIENT_SECRET=
+```
+
+credentials が空の場合のみ環境変数へ fallback します。client id と client secret の両方が設定されている場合だけ LINE ログインが有効になります。
+
+LINE channel が Developing の場合は利用者が制限されます。本番公開前に Published 状態と callback URL を確認してください。Email address permission が未承認の場合、LINE から email が返らないため、未ログインでの新規登録と既存 email アカウントへの自動連携は失敗します。`omniauth-line-v2` は LINE の `/oauth2/v2.1/verify` で検証済みの ID token response を `extra.id_info` として返します。このアプリでは取得 email と `extra.id_info.email` が一致する場合に LINE email を利用します。ログイン済みユーザーの本人アカウントへの LINE 連携は既存 OAuth 共通基盤の仕様どおり扱います。
+
+アプリ DB には LINE の access token、refresh token、raw_info は保存しません。
+
 ローカルでの確認手順:
+
+`.env` または Rails credentials に LINE credentials を設定してから起動します。`.env` を使う場合は以下のように設定し、実値をコミットしないでください。
+
+```bash
+LINE_CLIENT_ID=
+LINE_CLIENT_SECRET=
+```
 
 ```bash
 docker-compose up -d
@@ -119,7 +159,9 @@ docker-compose exec web rails db:prepare:development
 docker-compose exec web bin/dev
 ```
 
-`http://localhost:3000/users/sign_in` を開き、`admin@example.com` / `admin123` で通常ログインできることを確認します。Google credentials 未設定時は Google ボタンが表示されず、設定後に Rails を再起動すると `Googleでログイン` が表示されます。
+Rails credentials に設定済みの場合も、通常どおり `docker-compose up -d` で起動できます。
+
+`http://localhost:3000/users/sign_in` を開き、`admin@example.com` / `admin123` で通常ログインできることを確認します。Google credentials 未設定時は Google ボタンが表示されず、設定後に Rails を再起動すると `Googleでログイン` が表示されます。LINE credentials 未設定時は LINE ボタンが表示されず、設定後に Rails を再起動すると `LINEでログイン` が表示されます。
 
 ## テスト
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  %i[developer google_oauth2].each do |provider|
+  %i[developer google_oauth2 line].each do |provider|
     define_method(provider) do
       handle_callback
     end

--- a/app/javascript/controllers/oauth_consent_controller.js
+++ b/app/javascript/controllers/oauth_consent_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["checkbox", "button"]
+
+  connect() {
+    this.update()
+  }
+
+  update() {
+    const enabled = this.checkboxTarget.checked
+
+    this.buttonTargets.forEach((button) => {
+      button.disabled = !enabled
+      button.classList.toggle("cursor-not-allowed", !enabled)
+      button.classList.toggle("opacity-50", !enabled)
+    })
+  }
+}

--- a/app/services/oauth/auth_hash_reader.rb
+++ b/app/services/oauth/auth_hash_reader.rb
@@ -13,19 +13,20 @@ module Oauth
     end
 
     def email
-      @email ||= info_value(:email).to_s.strip.downcase.presence
+      @email ||= (info_value(:email).presence || raw_info_value(:email).presence).to_s.strip.downcase.presence
     end
 
     def name
-      @name ||= info_value(:name).presence
+      @name ||= info_value(:name).presence || raw_info_value(:name).presence
     end
 
     def image_url
-      @image_url ||= info_value(:image).presence || info_value(:image_url).presence
+      @image_url ||= info_value(:image).presence || info_value(:image_url).presence || raw_info_value(:picture).presence
     end
 
     def verified_email?
       return google_verified_email? if provider == 'google_oauth2'
+      return line_verified_email? if provider == 'line'
       return true if truthy?(info_value(:email_verified))
       return false unless raw_info_email_matches?
 
@@ -48,15 +49,43 @@ module Oauth
     end
 
     def raw_info_value(key)
-      fetch_value(fetch_value(auth_value(:extra), :raw_info), key)
+      fetch_value(profile_info, key)
+    end
+
+    def profile_info
+      extra = auth_value(:extra)
+      raw_info = fetch_value(extra, :raw_info)
+      return raw_info unless provider == 'line' && raw_info.blank?
+
+      fetch_value(extra, :id_info)
+    end
+
+    def id_info_value(key)
+      fetch_value(fetch_value(auth_value(:extra), :id_info), key)
     end
 
     def raw_info_email_matches?
       raw_info_value(:email).to_s.strip.downcase.presence == email
     end
 
+    def id_info_email_matches?
+      id_info_value(:email).to_s.strip.downcase.presence == email
+    end
+
     def google_verified_email?
       raw_info_email_matches? && raw_info_value(:email_verified) == true
+    end
+
+    def line_verified_email?
+      # omniauth-line-v2 verifies the ID token via LINE /oauth2/v2.1/verify
+      # and exposes that verified response as extra.id_info.
+      return true if id_info_email_matches?
+      return false unless raw_info_email_matches?
+
+      [
+        raw_info_value(:email_verified),
+        raw_info_value(:verified_email)
+      ].any?(true)
     end
 
     def fetch_value(object, key)

--- a/app/services/oauth/provider_config.rb
+++ b/app/services/oauth/provider_config.rb
@@ -2,33 +2,71 @@
 
 module Oauth
   class ProviderConfig
-    GOOGLE_PROVIDER = :google_oauth2
-    GOOGLE_CLIENT_ID_ENV = 'GOOGLE_CLIENT_ID'
-    GOOGLE_CLIENT_SECRET_ENV = 'GOOGLE_CLIENT_SECRET'
+    PROVIDERS = {
+      google_oauth2: {
+        credentials_key: :google_oauth,
+        env_client_id: 'GOOGLE_CLIENT_ID',
+        env_client_secret: 'GOOGLE_CLIENT_SECRET'
+      },
+      line: {
+        credentials_key: :line_oauth,
+        env_client_id: 'LINE_CLIENT_ID',
+        env_client_secret: 'LINE_CLIENT_SECRET'
+      }
+    }.freeze
 
     class << self
       def google_client_id
-        memoized(:@google_client_id) { configured_value(:client_id, GOOGLE_CLIENT_ID_ENV) }
+        client_id_for(:google_oauth2)
       end
 
       def google_client_secret
-        memoized(:@google_client_secret) { configured_value(:client_secret, GOOGLE_CLIENT_SECRET_ENV) }
+        client_secret_for(:google_oauth2)
       end
 
       def google_enabled?
-        google_client_id.present? && google_client_secret.present?
+        enabled?(:google_oauth2)
+      end
+
+      def line_client_id
+        client_id_for(:line)
+      end
+
+      def line_client_secret
+        client_secret_for(:line)
+      end
+
+      def line_enabled?
+        enabled?(:line)
       end
 
       def enabled_providers
-        google_enabled? ? [GOOGLE_PROVIDER] : []
+        memoized(:@enabled_providers) do
+          PROVIDERS.keys.filter { |provider| enabled?(provider) }
+        end
       end
 
       def reset!
-        remove_instance_variable(:@google_client_id) if instance_variable_defined?(:@google_client_id)
-        remove_instance_variable(:@google_client_secret) if instance_variable_defined?(:@google_client_secret)
+        PROVIDERS.each_key do |provider|
+          remove_memoized(:"@#{provider}_client_id")
+          remove_memoized(:"@#{provider}_client_secret")
+        end
+        remove_memoized(:@enabled_providers)
       end
 
       private
+
+      def enabled?(provider)
+        client_id_for(provider).present? && client_secret_for(provider).present?
+      end
+
+      def client_id_for(provider)
+        memoized(:"@#{provider}_client_id") { configured_value(provider, :client_id) }
+      end
+
+      def client_secret_for(provider)
+        memoized(:"@#{provider}_client_secret") { configured_value(provider, :client_secret) }
+      end
 
       def memoized(variable_name)
         return instance_variable_get(variable_name) if instance_variable_defined?(variable_name)
@@ -36,8 +74,14 @@ module Oauth
         instance_variable_set(variable_name, yield)
       end
 
-      def configured_value(credentials_key, env_key)
-        credentials_value = Rails.application.credentials.dig(:google_oauth, credentials_key)
+      def remove_memoized(variable_name)
+        remove_instance_variable(variable_name) if instance_variable_defined?(variable_name)
+      end
+
+      def configured_value(provider, value_key)
+        config = PROVIDERS.fetch(provider)
+        env_key = config.fetch(:"env_#{value_key}")
+        credentials_value = Rails.application.credentials.dig(config.fetch(:credentials_key), value_key)
         credentials_value.to_s.presence || ENV[env_key].to_s.presence
       end
     end

--- a/app/views/users/shared/_oauth_buttons.html.erb
+++ b/app/views/users/shared/_oauth_buttons.html.erb
@@ -1,4 +1,6 @@
-<% (User.omniauth_providers - [:developer]).select { |provider| provider == :google_oauth2 }.tap do |providers| %>
+<% (User.omniauth_providers - [:developer])
+     .filter { |provider| case provider when :google_oauth2, :line then true else false end }
+     .tap do |providers| %>
   <% if providers.present? %>
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <div class="relative my-6">
@@ -10,23 +12,55 @@
         </div>
       </div>
 
-      <div class="space-y-3">
+      <div class="space-y-3" data-controller="oauth-consent">
+        <div class="rounded-md border border-gray-200 bg-gray-50 p-3 text-xs leading-5 text-gray-600">
+          <p><%= t('devise.shared.oauth_buttons.consent.description') %></p>
+          <p class="mt-1">
+            <%= link_to t('devise.shared.oauth_buttons.consent.terms'), terms_of_use_path,
+                        class: 'font-medium text-sky-700 underline hover:text-sky-800' %>
+            <span class="mx-1">/</span>
+            <%= link_to t('devise.shared.oauth_buttons.consent.privacy'), privacy_policy_path,
+                        class: 'font-medium text-sky-700 underline hover:text-sky-800' %>
+          </p>
+          <label class="mt-3 flex items-start gap-2 text-gray-700">
+            <%= check_box_tag :oauth_consent, '1', false,
+                              class: 'mt-1 h-4 w-4 rounded border-gray-300 text-sky-600 focus:ring-sky-500',
+                              data: {
+                                oauth_consent_target: 'checkbox',
+                                action: 'oauth-consent#update'
+                              } %>
+            <span><%= t('devise.shared.oauth_buttons.consent.checkbox') %></span>
+          </label>
+        </div>
+
         <% providers.each do |provider| %>
           <%= button_to public_send(:"#{resource_name}_#{provider}_omniauth_authorize_path"),
                         method: :post,
                         form: { data: { turbo: false } },
+                        disabled: true,
+                        data: { oauth_consent_target: 'button' },
                         class: [
-                          'flex w-full items-center justify-center gap-3 rounded-md border border-gray-300 bg-white',
-                          'px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50',
-                          'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2'
+                          'flex w-full items-center justify-center gap-3 rounded-md',
+                          'px-4 py-2 text-sm font-semibold',
+                          'cursor-not-allowed opacity-50 focus:outline-none focus:ring-2 focus:ring-offset-2',
+                          case provider
+                          when :google_oauth2
+                            'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 focus:ring-sky-500'
+                          when :line
+                            'bg-[#06C755] text-white hover:bg-[#05b64d] focus:ring-[#06C755]'
+                          end
                         ].join(' ') do %>
-            <svg class="h-5 w-5" viewBox="0 0 18 18" aria-hidden="true" focusable="false">
-              <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.58 2.68-3.9 2.68-6.62z" />
-              <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.33-1.58-5.04-3.72H.94v2.34A9 9 0 0 0 9 18z" />
-              <path fill="#FBBC05" d="M3.96 10.7A5.4 5.4 0 0 1 3.68 9c0-.6.1-1.18.28-1.7V4.96H.94A9 9 0 0 0 0 9c0 1.45.35 2.82.94 4.04l3.02-2.34z" />
-              <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.34l2.58-2.58A8.66 8.66 0 0 0 9 0 9 9 0 0 0 .94 4.96L3.96 7.3C4.67 5.16 6.66 3.58 9 3.58z" />
-            </svg>
-            <span><%= t("devise.shared.oauth_buttons.google.#{mode}") %></span>
+            <% if provider == :google_oauth2 %>
+              <svg class="h-5 w-5" viewBox="0 0 18 18" aria-hidden="true" focusable="false">
+                <path fill="#4285F4" d="M17.64 9.2c0-.64-.06-1.25-.16-1.84H9v3.48h4.84a4.14 4.14 0 0 1-1.8 2.72v2.26h2.92c1.7-1.58 2.68-3.9 2.68-6.62z" />
+                <path fill="#34A853" d="M9 18c2.43 0 4.47-.8 5.96-2.18l-2.92-2.26c-.8.54-1.84.86-3.04.86-2.34 0-4.33-1.58-5.04-3.72H.94v2.34A9 9 0 0 0 9 18z" />
+                <path fill="#FBBC05" d="M3.96 10.7A5.4 5.4 0 0 1 3.68 9c0-.6.1-1.18.28-1.7V4.96H.94A9 9 0 0 0 0 9c0 1.45.35 2.82.94 4.04l3.02-2.34z" />
+                <path fill="#EA4335" d="M9 3.58c1.32 0 2.5.45 3.44 1.34l2.58-2.58A8.66 8.66 0 0 0 9 0 9 9 0 0 0 .94 4.96L3.96 7.3C4.67 5.16 6.66 3.58 9 3.58z" />
+              </svg>
+            <% elsif provider == :line %>
+              <span class="flex h-5 w-5 items-center justify-center rounded-sm bg-white text-sm font-bold text-[#06C755]" aria-hidden="true">L</span>
+            <% end %>
+            <span><%= t("devise.shared.oauth_buttons.#{provider == :google_oauth2 ? :google : provider}.#{mode}") %></span>
           <% end %>
         <% end %>
       </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -285,6 +285,13 @@ Devise.setup do |config|
                     scope: 'email,profile'
   end
 
+  if Oauth::ProviderConfig.line_enabled?
+    config.omniauth :line,
+                    Oauth::ProviderConfig.line_client_id,
+                    Oauth::ProviderConfig.line_client_secret,
+                    scope: 'profile openid email'
+  end
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -141,6 +141,14 @@ ja:
         google:
           sign_in: Googleでログイン
           sign_up: Googleで登録
+        line:
+          sign_in: LINEでログイン
+          sign_up: LINEで登録
+        consent:
+          description: 外部アカウントでのログインでは、連携先に登録されているメールアドレスを取得し、本人確認・アカウント管理・サポート対応に利用します。
+          terms: 利用規約
+          privacy: プライバシーポリシー
+          checkbox: 利用規約とプライバシーポリシーに同意して外部アカウントでログイン・登録する
         separator: または
       minimum_password_length: "（%{count}字以上）"
     unlocks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - 3000:3000
     depends_on:
       - db
+    environment:
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      LINE_CLIENT_ID: ${LINE_CLIENT_ID:-}
+      LINE_CLIENT_SECRET: ${LINE_CLIENT_SECRET:-}
     # railsでpryする用
     # true を指定することでコンテナを起動させ続ける。   
     tty: true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -43,6 +43,18 @@ RSpec.describe User do
       expect(described_class.omniauth_providers).to contain_exactly(:developer, :google_oauth2)
     end
 
+    it 'LINEが有効な場合はlineを含める' do
+      allow(Oauth::ProviderConfig).to receive(:enabled_providers).and_return([:line])
+
+      expect(described_class.omniauth_providers).to contain_exactly(:developer, :line)
+    end
+
+    it 'GoogleとLINEが有効な場合はProviderConfigの順序を維持する' do
+      allow(Oauth::ProviderConfig).to receive(:enabled_providers).and_return(%i[google_oauth2 line])
+
+      expect(described_class.omniauth_providers).to eq %i[developer google_oauth2 line]
+    end
+
     it 'Googleが無効な場合はgoogle_oauth2を含めない' do
       allow(Oauth::ProviderConfig).to receive(:enabled_providers).and_return([])
 
@@ -71,6 +83,28 @@ RSpec.describe User do
           load devise_initializer
 
           expect(Devise.omniauth_configs.keys).not_to include(:google_oauth2)
+        end
+      end
+    end
+
+    it 'LINEが有効な場合はDeviseにもlineを登録する' do
+      with_restored_devise_omniauth_configs do
+        with_line_oauth_credentials do
+          Devise.omniauth_configs.clear
+          load devise_initializer
+
+          expect(Devise.omniauth_configs.keys).to include(:line)
+        end
+      end
+    end
+
+    it 'LINEが無効な場合はDeviseにlineを登録しない' do
+      with_restored_devise_omniauth_configs do
+        with_line_oauth_credentials(client_id: nil, client_secret: nil) do
+          Devise.omniauth_configs.clear
+          load devise_initializer
+
+          expect(Devise.omniauth_configs.keys).not_to include(:line)
         end
       end
     end

--- a/spec/requests/users/omniauth_callbacks_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Users::omniauth_callbacks' do
     original_test_mode = OmniAuth.config.test_mode
     original_developer_auth = OmniAuth.config.mock_auth[:developer]
     original_google_auth = OmniAuth.config.mock_auth[:google_oauth2]
+    original_line_auth = OmniAuth.config.mock_auth[:line]
 
     OmniAuth.config.test_mode = true
     OmniAuth.config.mock_auth[:developer] = auth
@@ -13,6 +14,7 @@ RSpec.describe 'Users::omniauth_callbacks' do
   ensure
     OmniAuth.config.mock_auth[:developer] = original_developer_auth
     OmniAuth.config.mock_auth[:google_oauth2] = original_google_auth
+    OmniAuth.config.mock_auth[:line] = original_line_auth
     OmniAuth.config.test_mode = original_test_mode
   end
 
@@ -352,6 +354,185 @@ RSpec.describe 'Users::omniauth_callbacks' do
         end.not_to(change { [User.count, UserIdentity.count] })
 
         expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.failure')
+      end
+    end
+  end
+
+  describe 'GET /users/auth/line/callback' do
+    around do |example|
+      with_oauth_routes(providers: [:line]) { example.run }
+    end
+
+    before do
+      OmniAuth.config.mock_auth[:line] = auth
+    end
+
+    def line_callback(params: {})
+      get user_line_omniauth_callback_path(params), env: { 'omniauth.auth' => auth }
+    end
+
+    let(:auth) do
+      mock_line_auth_hash(
+        uid: 'line-uid-123',
+        email: 'line-user@example.com',
+        name: 'LINE User',
+        image: 'https://example.com/line-avatar.png',
+        credentials: {
+          token: 'line-access-token',
+          refresh_token: 'line-refresh-token'
+        }
+      )
+    end
+
+    it 'verified emailで未登録ユーザーを作成してログインする' do
+      expect do
+        line_callback
+      end.to change(User, :count).by(1).and change(UserIdentity, :count).by(1)
+
+      identity = UserIdentity.find_by!(provider: 'line', uid: 'line-uid-123')
+      aggregate_failures do
+        expect(response).to redirect_to(root_path)
+        expect(controller.current_user).to eq identity.user
+        expect(identity.email).to eq 'line-user@example.com'
+        expect(identity.name).to eq 'LINE User'
+        expect(identity.image_url).to eq 'https://example.com/line-avatar.png'
+      end
+    end
+
+    it 'tokenやraw_infoをUserIdentityへ保存しない' do
+      line_callback
+
+      identity = UserIdentity.find_by!(provider: 'line', uid: 'line-uid-123')
+      aggregate_failures do
+        expect(identity.attributes).not_to include('token')
+        expect(identity.attributes).not_to include('refresh_token')
+        expect(identity.attributes).not_to include('raw_info')
+      end
+    end
+
+    context 'verified emailの既存ユーザーがいる場合' do
+      let!(:user) { create(:user, email: 'line-user@example.com') }
+
+      it '既存ユーザーに自動連携してログインする' do
+        user_count = User.count
+
+        expect do
+          line_callback
+        end.to change(user.user_identities, :count).by(1)
+
+        expect(User.count).to eq user_count
+        expect(response).to redirect_to(root_path)
+        expect(controller.current_user).to eq user
+      end
+    end
+
+    context '既存LINE identityがある場合' do
+      let!(:identity) { create(:user_identity, provider: 'line', uid: 'line-uid-123') }
+
+      it '紐づくユーザーでログインする' do
+        line_callback
+
+        expect(response).to redirect_to(root_path)
+        expect(controller.current_user).to eq identity.user
+      end
+    end
+
+    context 'emailはあるがverified claimがない場合' do
+      let(:auth) do
+        mock_line_auth_hash(
+          email: 'line-user@example.com',
+          raw_info: { email: 'line-user@example.com', name: 'LINE User' }
+        )
+      end
+
+      it '未ログインでは新規作成せずログイン画面へ戻す' do
+        expect do
+          line_callback
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.unverified_email')
+      end
+    end
+
+    context 'verified claimがfalseの場合' do
+      let(:auth) do
+        mock_line_auth_hash(
+          email: 'line-user@example.com',
+          raw_info: { email: 'line-user@example.com', email_verified: false, verified_email: false }
+        )
+      end
+
+      it '未ログインでは新規作成せずログイン画面へ戻す' do
+        expect do
+          line_callback
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.unverified_email')
+      end
+    end
+
+    context 'emailがない場合' do
+      let(:auth) do
+        mock_line_auth_hash(email: nil, raw_info: { name: 'LINE User', email_verified: true })
+      end
+
+      it '未ログインでは新規作成せずログイン画面へ戻す' do
+        expect do
+          line_callback
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.unverified_email')
+      end
+    end
+
+    context 'ログイン中の場合' do
+      let(:user) { create(:user) }
+      let(:auth) do
+        mock_line_auth_hash(email: nil, raw_info: { name: 'LINE User' })
+      end
+
+      before { sign_in user }
+
+      it 'emailなしでもログイン中ユーザー本人へ連携する' do
+        expect do
+          line_callback
+        end.to change(user.user_identities, :count).by(1)
+
+        identity = user.user_identities.find_by!(provider: 'line', uid: 'line-uid-123')
+        expect(response).to redirect_to(root_path)
+        expect(identity.email).to be_nil
+      end
+    end
+
+    context 'ゲストユーザーでログイン中の場合' do
+      let(:guest_user) { create(:user, :guest) }
+
+      before { sign_in guest_user }
+
+      it '連携せずアカウント画面へ戻す' do
+        expect do
+          line_callback
+        end.not_to change(guest_user.user_identities, :count)
+
+        expect(response).to redirect_to(account_path)
+        expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.guest_user_not_allowed')
+      end
+    end
+
+    context 'callback providerとauth.providerが一致しない場合' do
+      let(:auth) { auth_hash(provider: 'google_oauth2', uid: 'google-uid-123') }
+
+      it 'identityを作成せず失敗する' do
+        expect do
+          line_callback(params: { redirect_url: 'https://evil.example.com' })
+        end.not_to(change { [User.count, UserIdentity.count] })
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(response).not_to redirect_to('https://evil.example.com')
         expect(flash[:alert]).to eq I18n.t('oauth.identity_authenticator.failure')
       end
     end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Users::registrations' do
         get new_user_registration_path
 
         expect(response.body).not_to include('Googleで登録')
+        expect(response.body).not_to include('LINEで登録')
       end
     end
 
@@ -32,9 +33,56 @@ RSpec.describe 'Users::registrations' do
           expect(response.body).to include('Googleで登録')
           expect(google_form).to be_present
           expect(google_form.at_css('svg')).to be_present
+          expect(google_form.at_css('button[disabled]')).to be_present
+          expect(response.body).to include('外部アカウントでのログインでは、連携先に登録されているメールアドレスを取得し')
+          expect(response.body).to include(terms_of_use_path)
+          expect(response.body).to include(privacy_policy_path)
           expect(response.body.index('action="/users"'))
             .to be < response.body.index('action="/users/auth/google_oauth2"')
           expect(response.body).not_to include('href="/users/auth/google_oauth2"')
+        end
+      end
+    end
+
+    it 'LINEが有効な場合はPOSTのLINE登録ボタンを表示する' do
+      with_oauth_routes(providers: [:line]) do
+        get new_user_registration_path
+        line_form = parsed_response.at_css(
+          'form[action="/users/auth/line"][method="post"][data-turbo="false"]'
+        )
+
+        aggregate_failures do
+          expect(response.body).to include('LINEで登録')
+          expect(line_form).to be_present
+          expect(line_form.at_css('button[disabled]')).to be_present
+          expect(response.body).to include('外部アカウントでのログインでは、連携先に登録されているメールアドレスを取得し')
+          expect(response.body).to include('利用規約とプライバシーポリシーに同意')
+          expect(response.body).not_to include('href="/users/auth/line"')
+          expect(response.body).not_to include('Googleで登録')
+          expect(response.body).not_to include('/users/auth/developer')
+        end
+      end
+    end
+
+    it 'GoogleとLINEが有効な場合はGoogleからLINEの順でPOST登録ボタンを表示する' do
+      with_oauth_routes(providers: %i[google_oauth2 line]) do
+        get new_user_registration_path
+        google_form = parsed_response.at_css(
+          'form[action="/users/auth/google_oauth2"][method="post"][data-turbo="false"]'
+        )
+        line_form = parsed_response.at_css(
+          'form[action="/users/auth/line"][method="post"][data-turbo="false"]'
+        )
+
+        aggregate_failures do
+          expect(google_form).to be_present
+          expect(line_form).to be_present
+          expect(google_form.at_css('button[disabled]')).to be_present
+          expect(line_form.at_css('button[disabled]')).to be_present
+          expect(response.body.index('action="/users/auth/google_oauth2"'))
+            .to be < response.body.index('action="/users/auth/line"')
+          expect(response.body).not_to include('href="/users/auth/google_oauth2"')
+          expect(response.body).not_to include('href="/users/auth/line"')
         end
       end
     end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe 'Users::sessions' do
           expect(response.body).to include('name="user[password]"')
           expect(response.body).to include('value="ログイン"')
           expect(response.body).not_to include('Googleでログイン')
+          expect(response.body).not_to include('LINEでログイン')
         end
 
         post user_session_path, params: { user: { email: seed_admin.email, password: seed_admin_password } }
@@ -121,6 +122,10 @@ RSpec.describe 'Users::sessions' do
           expect(response.body).to include('Googleでログイン')
           expect(google_form).to be_present
           expect(google_form.at_css('svg')).to be_present
+          expect(google_form.at_css('button[disabled]')).to be_present
+          expect(response.body).to include('外部アカウントでのログインでは、連携先に登録されているメールアドレスを取得し')
+          expect(response.body).to include(terms_of_use_path)
+          expect(response.body).to include(privacy_policy_path)
           expect(response.body.index('action="/users/sign_in"'))
             .to be < response.body.index('action="/users/auth/google_oauth2"')
           expect(response.body).to include('name="user[email]"')
@@ -131,6 +136,50 @@ RSpec.describe 'Users::sessions' do
 
         post user_session_path, params: { user: { email: seed_admin.email, password: seed_admin_password } }
         expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    it 'LINEが有効な場合はPOSTのLINEログインボタンを表示する' do
+      with_oauth_routes(providers: [:line]) do
+        get new_user_session_path
+        line_form = parsed_response.at_css(
+          'form[action="/users/auth/line"][method="post"][data-turbo="false"]'
+        )
+
+        aggregate_failures do
+          expect(response.body).to include('LINEでログイン')
+          expect(line_form).to be_present
+          expect(line_form.at_css('button[disabled]')).to be_present
+          expect(response.body).to include('外部アカウントでのログインでは、連携先に登録されているメールアドレスを取得し')
+          expect(response.body).to include('利用規約とプライバシーポリシーに同意')
+          expect(response.body).not_to include('href="/users/auth/line"')
+          expect(response.body).not_to include('Googleでログイン')
+          expect(response.body).not_to include('Developer')
+        end
+      end
+    end
+
+    it 'GoogleとLINEが有効な場合はGoogleからLINEの順でPOSTボタンを表示する' do
+      with_oauth_routes(providers: %i[google_oauth2 line]) do
+        get new_user_session_path
+        google_form = parsed_response.at_css(
+          'form[action="/users/auth/google_oauth2"][method="post"][data-turbo="false"]'
+        )
+        line_form = parsed_response.at_css(
+          'form[action="/users/auth/line"][method="post"][data-turbo="false"]'
+        )
+
+        aggregate_failures do
+          expect(google_form).to be_present
+          expect(line_form).to be_present
+          expect(google_form.at_css('button[disabled]')).to be_present
+          expect(line_form.at_css('button[disabled]')).to be_present
+          expect(response.body.index('action="/users/auth/google_oauth2"'))
+            .to be < response.body.index('action="/users/auth/line"')
+          expect(response.body).not_to include('href="/users/auth/google_oauth2"')
+          expect(response.body).not_to include('href="/users/auth/line"')
+          expect(response.body).not_to include('/users/auth/developer')
+        end
       end
     end
   end

--- a/spec/services/oauth/auth_hash_reader_spec.rb
+++ b/spec/services/oauth/auth_hash_reader_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Oauth::AuthHashReader do
+  subject(:reader) { described_class.new(auth) }
+
+  def auth_hash(provider: 'line', uid: 'line-uid-123', info: {}, raw_info: {})
+    OmniAuth::AuthHash.new(
+      provider:,
+      uid:,
+      info:,
+      extra: { raw_info: }
+    )
+  end
+
+  def line_auth_hash(info: {}, raw_info: nil, id_info: nil)
+    extra = {}
+    extra[:raw_info] = raw_info if raw_info
+    extra[:id_info] = id_info if id_info
+
+    OmniAuth::AuthHash.new(
+      provider: 'line',
+      uid: 'line-uid-123',
+      info:,
+      extra:
+    )
+  end
+
+  describe '#email' do
+    it 'info.emailを正規化して返す' do
+      auth = auth_hash(info: { email: ' LINE_USER@EXAMPLE.COM ' })
+
+      expect(described_class.new(auth).email).to eq 'line_user@example.com'
+    end
+
+    it 'info.emailがない場合はraw_info.emailを読む' do
+      auth = auth_hash(info: {}, raw_info: { email: 'line-user@example.com' })
+
+      expect(described_class.new(auth).email).to eq 'line-user@example.com'
+    end
+
+    it 'LINEでraw_infoがない場合はid_info.emailを読む' do
+      auth = line_auth_hash(info: {}, id_info: { email: 'line-user@example.com' })
+
+      expect(described_class.new(auth).email).to eq 'line-user@example.com'
+    end
+  end
+
+  describe '#name' do
+    it 'info.nameを返す' do
+      auth = auth_hash(info: { name: 'Info Name' }, raw_info: { name: 'Raw Name' })
+
+      expect(described_class.new(auth).name).to eq 'Info Name'
+    end
+
+    it 'info.nameがない場合はraw_info.nameを返す' do
+      auth = auth_hash(info: {}, raw_info: { name: 'Raw Name' })
+
+      expect(described_class.new(auth).name).to eq 'Raw Name'
+    end
+
+    it 'LINEでraw_infoがない場合はid_info.nameを返す' do
+      auth = line_auth_hash(info: {}, id_info: { name: 'ID Name' })
+
+      expect(described_class.new(auth).name).to eq 'ID Name'
+    end
+  end
+
+  describe '#image_url' do
+    it 'info.imageを返す' do
+      auth = auth_hash(info: { image: 'https://example.com/info.png' },
+                       raw_info: { picture: 'https://example.com/raw.png' })
+
+      expect(described_class.new(auth).image_url).to eq 'https://example.com/info.png'
+    end
+
+    it 'info.imageがない場合はraw_info.pictureを返す' do
+      auth = auth_hash(info: {}, raw_info: { picture: 'https://example.com/raw.png' })
+
+      expect(described_class.new(auth).image_url).to eq 'https://example.com/raw.png'
+    end
+
+    it 'LINEでraw_infoがない場合はid_info.pictureを返す' do
+      auth = line_auth_hash(info: {}, id_info: { picture: 'https://example.com/id.png' })
+
+      expect(described_class.new(auth).image_url).to eq 'https://example.com/id.png'
+    end
+  end
+
+  describe '#verified_email?' do
+    context 'Googleの場合' do
+      it 'raw_info.email_verifiedがboolean trueでemailが一致する場合のみtrueを返す' do
+        auth = auth_hash(
+          provider: 'google_oauth2',
+          info: { email: 'google-user@example.com', email_verified: true },
+          raw_info: { email: 'google-user@example.com', email_verified: true }
+        )
+
+        expect(described_class.new(auth)).to be_verified_email
+      end
+
+      it 'info.email_verifiedがtrueでもraw_info.email_verifiedがtrueでなければfalseを返す' do
+        auth = auth_hash(
+          provider: 'google_oauth2',
+          info: { email: 'google-user@example.com', email_verified: true },
+          raw_info: { email: 'google-user@example.com', email_verified: 'true' }
+        )
+
+        expect(described_class.new(auth)).not_to be_verified_email
+      end
+    end
+
+    context 'LINEの場合' do
+      it 'id_info.emailが取得emailと一致する場合にtrueを返す' do
+        auth = line_auth_hash(
+          info: { email: 'line-user@example.com' },
+          id_info: { email: 'line-user@example.com', name: 'LINE User' }
+        )
+
+        expect(described_class.new(auth)).to be_verified_email
+      end
+
+      it 'raw_info.email_verifiedがboolean trueでemailが一致する場合にtrueを返す' do
+        auth = auth_hash(
+          info: { email: 'line-user@example.com' },
+          raw_info: { email: 'line-user@example.com', email_verified: true }
+        )
+
+        expect(described_class.new(auth)).to be_verified_email
+      end
+
+      it 'raw_info.verified_emailがboolean trueでemailが一致する場合にtrueを返す' do
+        auth = auth_hash(
+          info: { email: 'line-user@example.com' },
+          raw_info: { email: 'line-user@example.com', verified_email: true }
+        )
+
+        expect(described_class.new(auth)).to be_verified_email
+      end
+
+      it 'raw_infoがない場合はid_info.email一致でtrueを返す' do
+        auth = line_auth_hash(
+          info: { email: 'line-user@example.com' },
+          id_info: { email: 'line-user@example.com' }
+        )
+
+        expect(described_class.new(auth)).to be_verified_email
+      end
+
+      it 'emailが存在するだけではtrueを返さない' do
+        auth = auth_hash(
+          info: { email: 'line-user@example.com' },
+          raw_info: { email: 'line-user@example.com' }
+        )
+
+        expect(described_class.new(auth)).not_to be_verified_email
+      end
+
+      it 'verified claimがfalseの場合はfalseを返す' do
+        auth = auth_hash(
+          info: { email: 'line-user@example.com' },
+          raw_info: { email: 'line-user@example.com', email_verified: false, verified_email: false }
+        )
+
+        expect(described_class.new(auth)).not_to be_verified_email
+      end
+
+      it 'verified claimが文字列trueの場合はfalseを返す' do
+        auth = auth_hash(
+          info: { email: 'line-user@example.com' },
+          raw_info: { email: 'line-user@example.com', email_verified: 'true' }
+        )
+
+        expect(described_class.new(auth)).not_to be_verified_email
+      end
+
+      it 'raw_info.emailと取得emailが一致しない場合はfalseを返す' do
+        auth = auth_hash(
+          info: { email: 'line-user@example.com' },
+          raw_info: { email: 'other@example.com', email_verified: true }
+        )
+
+        expect(described_class.new(auth)).not_to be_verified_email
+      end
+
+      it 'id_info.emailと取得emailが一致しない場合はfalseを返す' do
+        auth = line_auth_hash(
+          info: { email: 'line-user@example.com' },
+          id_info: { email: 'other@example.com' }
+        )
+
+        expect(described_class.new(auth)).not_to be_verified_email
+      end
+    end
+  end
+end

--- a/spec/services/oauth/identity_authenticator_spec.rb
+++ b/spec/services/oauth/identity_authenticator_spec.rb
@@ -160,6 +160,42 @@ RSpec.describe Oauth::IdentityAuthenticator do
         end
       end
 
+      context 'LINEでemailはあるがverified claimがない場合' do
+        let!(:user) { create(:user, email: 'user@example.com') }
+        let(:auth) do
+          auth_hash(
+            provider: 'line',
+            uid: 'line-uid-123',
+            email_verified: nil,
+            raw_info: { email: 'user@example.com' }
+          )
+        end
+
+        it 'emailが一致しても自動連携も新規作成もしない' do
+          expect { result }.not_to change(UserIdentity, :count)
+          expect(result).not_to be_success
+          expect(user.reload.user_identities).to be_empty
+        end
+      end
+
+      context 'LINEでverified emailを確認できる場合' do
+        let!(:user) { create(:user, email: 'user@example.com') }
+        let(:auth) do
+          auth_hash(
+            provider: 'line',
+            uid: 'line-uid-123',
+            email_verified: nil,
+            raw_info: { email: 'user@example.com', email_verified: true }
+          )
+        end
+
+        it '既存ユーザーへ自動連携する' do
+          expect { result }.to change(user.user_identities, :count).by(1)
+          expect(result).to be_success
+          expect(result.identity.provider).to eq 'line'
+        end
+      end
+
       context 'email_verifiedがnilの場合' do
         let(:auth) { auth_hash(email_verified: nil) }
 

--- a/spec/services/oauth/provider_config_spec.rb
+++ b/spec/services/oauth/provider_config_spec.rb
@@ -4,61 +4,77 @@ require 'rails_helper'
 
 RSpec.describe Oauth::ProviderConfig do
   around do |example|
-    original_client_id = ENV.fetch('GOOGLE_CLIENT_ID', nil)
-    original_client_secret = ENV.fetch('GOOGLE_CLIENT_SECRET', nil)
-    ENV.delete('GOOGLE_CLIENT_ID')
-    ENV.delete('GOOGLE_CLIENT_SECRET')
+    original_env = {
+      'GOOGLE_CLIENT_ID' => ENV.fetch('GOOGLE_CLIENT_ID', nil),
+      'GOOGLE_CLIENT_SECRET' => ENV.fetch('GOOGLE_CLIENT_SECRET', nil),
+      'LINE_CLIENT_ID' => ENV.fetch('LINE_CLIENT_ID', nil),
+      'LINE_CLIENT_SECRET' => ENV.fetch('LINE_CLIENT_SECRET', nil)
+    }
+
+    original_env.each_key { |key| ENV.delete(key) }
     described_class.reset!
 
     example.run
   ensure
-    original_client_id.nil? ? ENV.delete('GOOGLE_CLIENT_ID') : ENV['GOOGLE_CLIENT_ID'] = original_client_id
-    if original_client_secret.nil?
-      ENV.delete('GOOGLE_CLIENT_SECRET')
-    else
-      ENV['GOOGLE_CLIENT_SECRET'] = original_client_secret
+    original_env.each do |key, value|
+      value.nil? ? ENV.delete(key) : ENV[key] = value
     end
     described_class.reset!
   end
 
-  def stub_google_credentials(client_id:, client_secret:)
+  def stub_oauth_credentials(google_client_id: nil, google_client_secret: nil, line_client_id: nil,
+                             line_client_secret: nil)
     described_class.reset!
     allow(Rails.application.credentials).to receive(:dig).and_call_original
-    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_id).and_return(client_id)
-    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_secret).and_return(client_secret)
+    stub_google_credentials(client_id: google_client_id, client_secret: google_client_secret)
+    stub_line_credentials(client_id: line_client_id, client_secret: line_client_secret)
+  end
+
+  def stub_google_credentials(client_id:, client_secret:)
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:google_oauth, :client_id).and_return(client_id)
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:google_oauth, :client_secret).and_return(client_secret)
+  end
+
+  def stub_line_credentials(client_id:, client_secret:)
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:line_oauth, :client_id).and_return(client_id)
+    allow(Rails.application.credentials).to receive(:dig)
+      .with(:line_oauth, :client_secret).and_return(client_secret)
   end
 
   describe '.google_enabled?' do
     it 'client idとsecretが両方ある場合にtrueを返す' do
-      stub_google_credentials(client_id: 'credential-id', client_secret: 'credential-secret')
+      stub_oauth_credentials(google_client_id: 'credential-id', google_client_secret: 'credential-secret')
 
       expect(described_class).to be_google_enabled
       expect(described_class.enabled_providers).to eq [:google_oauth2]
     end
 
     it 'client idのみの場合にfalseを返す' do
-      stub_google_credentials(client_id: 'credential-id', client_secret: nil)
+      stub_oauth_credentials(google_client_id: 'credential-id', google_client_secret: nil)
 
       expect(described_class).not_to be_google_enabled
       expect(described_class.enabled_providers).to be_empty
     end
 
     it 'client secretのみの場合にfalseを返す' do
-      stub_google_credentials(client_id: nil, client_secret: 'credential-secret')
+      stub_oauth_credentials(google_client_id: nil, google_client_secret: 'credential-secret')
 
       expect(described_class).not_to be_google_enabled
       expect(described_class.enabled_providers).to be_empty
     end
 
     it 'blankは未設定として扱う' do
-      stub_google_credentials(client_id: ' ', client_secret: '')
+      stub_oauth_credentials(google_client_id: ' ', google_client_secret: '')
 
       expect(described_class).not_to be_google_enabled
       expect(described_class.enabled_providers).to be_empty
     end
 
     it 'credentialsをENVより優先する' do
-      stub_google_credentials(client_id: 'credential-id', client_secret: 'credential-secret')
+      stub_oauth_credentials(google_client_id: 'credential-id', google_client_secret: 'credential-secret')
       ENV['GOOGLE_CLIENT_ID'] = 'env-id'
       ENV['GOOGLE_CLIENT_SECRET'] = 'env-secret'
 
@@ -67,13 +83,96 @@ RSpec.describe Oauth::ProviderConfig do
     end
 
     it 'credentialsがblankの場合はENVへfallbackする' do
-      stub_google_credentials(client_id: ' ', client_secret: nil)
+      stub_oauth_credentials(google_client_id: ' ', google_client_secret: nil)
       ENV['GOOGLE_CLIENT_ID'] = 'env-id'
       ENV['GOOGLE_CLIENT_SECRET'] = 'env-secret'
 
       expect(described_class).to be_google_enabled
       expect(described_class.google_client_id).to eq 'env-id'
       expect(described_class.google_client_secret).to eq 'env-secret'
+    end
+  end
+
+  describe '.line_enabled?' do
+    it 'line_oauthのclient idとsecretが両方ある場合にtrueを返す' do
+      stub_oauth_credentials(line_client_id: 'line-credential-id', line_client_secret: 'line-credential-secret')
+
+      expect(described_class).to be_line_enabled
+      expect(described_class.enabled_providers).to eq [:line]
+    end
+
+    it 'client idのみの場合にfalseを返す' do
+      stub_oauth_credentials(line_client_id: 'line-credential-id', line_client_secret: nil)
+
+      expect(described_class).not_to be_line_enabled
+      expect(described_class.enabled_providers).to be_empty
+    end
+
+    it 'client secretのみの場合にfalseを返す' do
+      stub_oauth_credentials(line_client_id: nil, line_client_secret: 'line-credential-secret')
+
+      expect(described_class).not_to be_line_enabled
+      expect(described_class.enabled_providers).to be_empty
+    end
+
+    it 'credentialsをENVより優先する' do
+      stub_oauth_credentials(line_client_id: 'line-credential-id', line_client_secret: 'line-credential-secret')
+      ENV['LINE_CLIENT_ID'] = 'line-env-id'
+      ENV['LINE_CLIENT_SECRET'] = 'line-env-secret'
+
+      expect(described_class.line_client_id).to eq 'line-credential-id'
+      expect(described_class.line_client_secret).to eq 'line-credential-secret'
+    end
+
+    it 'credentialsがblankの場合はENVへfallbackする' do
+      stub_oauth_credentials(line_client_id: '', line_client_secret: ' ')
+      ENV['LINE_CLIENT_ID'] = 'line-env-id'
+      ENV['LINE_CLIENT_SECRET'] = 'line-env-secret'
+
+      expect(described_class).to be_line_enabled
+      expect(described_class.line_client_id).to eq 'line-env-id'
+      expect(described_class.line_client_secret).to eq 'line-env-secret'
+    end
+  end
+
+  describe '.enabled_providers' do
+    it 'Googleのみ有効な場合はgoogle_oauth2のみ返す' do
+      stub_oauth_credentials(google_client_id: 'google-id', google_client_secret: 'google-secret')
+
+      expect(described_class.enabled_providers).to eq [:google_oauth2]
+    end
+
+    it 'LINEのみ有効な場合はlineのみ返す' do
+      stub_oauth_credentials(line_client_id: 'line-id', line_client_secret: 'line-secret')
+
+      expect(described_class.enabled_providers).to eq [:line]
+    end
+
+    it 'GoogleとLINEが有効な場合はGoogleからLINEの順で返す' do
+      stub_oauth_credentials(
+        google_client_id: 'google-id',
+        google_client_secret: 'google-secret',
+        line_client_id: 'line-id',
+        line_client_secret: 'line-secret'
+      )
+
+      expect(described_class.enabled_providers).to eq %i[google_oauth2 line]
+    end
+
+    it 'GoogleとLINEが無効な場合は空配列を返す' do
+      stub_oauth_credentials
+
+      expect(described_class.enabled_providers).to be_empty
+    end
+
+    it 'reset!後にenabled_providersのキャッシュを更新する' do
+      stub_oauth_credentials(google_client_id: 'google-id', google_client_secret: 'google-secret')
+      expect(described_class.enabled_providers).to eq [:google_oauth2]
+
+      stub_oauth_credentials(line_client_id: 'line-id', line_client_secret: 'line-secret')
+      described_class.reset!
+
+      expect(described_class.enabled_providers).to eq [:line]
     end
   end
 end

--- a/spec/support/oauth_test_helpers.rb
+++ b/spec/support/oauth_test_helpers.rb
@@ -1,12 +1,19 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/ModuleLength
 module OauthTestHelpers
   GOOGLE_CLIENT_ID = 'google-client-id'
   GOOGLE_CLIENT_SECRET = 'google-client-secret'
+  LINE_CLIENT_ID = 'line-client-id'
+  LINE_CLIENT_SECRET = 'line-client-secret'
 
-  def with_google_oauth_routes(enabled: true)
+  def with_google_oauth_routes(enabled: true, &)
+    with_oauth_routes(providers: enabled ? [:google_oauth2] : [], &)
+  end
+
+  def with_oauth_routes(providers:)
     original_enabled_providers = Oauth::ProviderConfig.singleton_class.instance_method(:enabled_providers)
-    replace_enabled_providers(enabled ? [:google_oauth2] : [])
+    replace_enabled_providers(providers)
     Rails.application.reload_routes!
 
     yield
@@ -16,17 +23,52 @@ module OauthTestHelpers
   end
 
   def with_google_oauth_credentials(client_id: GOOGLE_CLIENT_ID, client_secret: GOOGLE_CLIENT_SECRET,
-                                    env_client_id: nil, env_client_secret: nil)
-    original_env = google_oauth_env
-    set_google_oauth_env(client_id: env_client_id, client_secret: env_client_secret)
+                                    env_client_id: nil, env_client_secret: nil, &)
+    with_oauth_credentials(
+      config: oauth_config(:google_oauth, 'GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET'),
+      client_id:,
+      client_secret:,
+      env_client_id:,
+      env_client_secret:,
+      &
+    )
+  end
+
+  def with_line_oauth_credentials(client_id: LINE_CLIENT_ID, client_secret: LINE_CLIENT_SECRET,
+                                  env_client_id: nil, env_client_secret: nil, &)
+    with_oauth_credentials(
+      config: oauth_config(:line_oauth, 'LINE_CLIENT_ID', 'LINE_CLIENT_SECRET'),
+      client_id:,
+      client_secret:,
+      env_client_id:,
+      env_client_secret:,
+      &
+    )
+  end
+
+  def with_oauth_credentials(config:, client_id:, client_secret:, env_client_id:, env_client_secret:)
+    original_env = oauth_env(config)
+    set_oauth_env(config, client_id: env_client_id, client_secret: env_client_secret)
     Oauth::ProviderConfig.reset!
 
-    stub_google_oauth_credentials(client_id:, client_secret:)
+    stub_oauth_credentials(provider: config[:provider], client_id:, client_secret:)
 
     yield
   ensure
-    set_google_oauth_env(**original_env)
+    set_oauth_env(config, **original_env)
     Oauth::ProviderConfig.reset!
+  end
+
+  def mock_line_auth_hash(**overrides)
+    attributes = default_line_auth_attributes.merge(overrides)
+
+    OmniAuth::AuthHash.new(
+      provider: 'line',
+      uid: attributes[:uid],
+      info: line_auth_info(attributes),
+      credentials: attributes[:credentials],
+      extra: line_auth_extra(attributes)
+    )
   end
 
   def with_restored_devise_omniauth_configs
@@ -48,28 +90,71 @@ module OauthTestHelpers
     Oauth::ProviderConfig.singleton_class.define_method(:enabled_providers, original_enabled_providers)
   end
 
-  def google_oauth_env
+  def oauth_config(provider, client_id_key, client_secret_key)
     {
-      client_id: ENV.fetch('GOOGLE_CLIENT_ID', nil),
-      client_secret: ENV.fetch('GOOGLE_CLIENT_SECRET', nil)
+      provider:,
+      client_id_key:,
+      client_secret_key:
     }
   end
 
-  def set_google_oauth_env(client_id:, client_secret:)
-    set_env('GOOGLE_CLIENT_ID', client_id)
-    set_env('GOOGLE_CLIENT_SECRET', client_secret)
+  def oauth_env(config)
+    {
+      client_id: ENV.fetch(config[:client_id_key], nil),
+      client_secret: ENV.fetch(config[:client_secret_key], nil)
+    }
   end
 
-  def stub_google_oauth_credentials(client_id:, client_secret:)
+  def set_oauth_env(config, client_id:, client_secret:)
+    set_env(config[:client_id_key], client_id)
+    set_env(config[:client_secret_key], client_secret)
+  end
+
+  def stub_oauth_credentials(provider:, client_id:, client_secret:)
     allow(Rails.application.credentials).to receive(:dig).and_call_original
-    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_id).and_return(client_id)
-    allow(Rails.application.credentials).to receive(:dig).with(:google_oauth, :client_secret).and_return(client_secret)
+    allow(Rails.application.credentials).to receive(:dig).with(provider, :client_id).and_return(client_id)
+    allow(Rails.application.credentials).to receive(:dig).with(provider, :client_secret).and_return(client_secret)
   end
 
   def set_env(key, value)
     value.nil? ? ENV.delete(key) : ENV[key] = value
   end
+
+  def default_line_auth_attributes
+    {
+      uid: 'line-uid-123',
+      email: 'line-user@example.com',
+      name: 'LINE User',
+      image: 'https://example.com/line-avatar.png',
+      raw_info: nil,
+      id_info: nil,
+      credentials: nil
+    }
+  end
+
+  def line_id_info(attributes)
+    return attributes[:id_info] if attributes[:id_info]
+    return if attributes[:raw_info]
+
+    {
+      email: attributes[:email],
+      name: attributes[:name],
+      picture: attributes[:image]
+    }
+  end
+
+  def line_auth_info(attributes)
+    attributes.slice(:email, :name, :image)
+  end
+
+  def line_auth_extra(attributes)
+    {}.tap do |extra|
+      extra[:raw_info] = attributes[:raw_info] if attributes[:raw_info]
+      extra[:id_info] = line_id_info(attributes) if line_id_info(attributes)
+    end
+  end
 end
+# rubocop:enable Metrics/ModuleLength
 
 RSpec.configure do |config|
   config.include OauthTestHelpers


### PR DESCRIPTION
対応するissue
---
Closes #186

概要
---

LINE Login を OAuth ログイン手段として追加しました。

Google OAuth で導入済みの共通基盤を流用し、LINE provider の設定管理、Devise OmniAuth 登録、callback 処理、ログイン/登録画面の LINE ボタン表示、LINE email 権限申請向けの同意表示、README の設定手順、RSpec を追加しています。

LINE Developers Console の callback URL は以下を想定しています。

- local: `http://localhost:3000/users/auth/line/callback`
- production: `https://app.kokushiex.com/users/auth/line/callback`

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `POST /users/auth/line` | `users/omniauth_callbacks#passthru` | LINE Login の OmniAuth request phase を開始する |
| `GET /users/auth/line/callback` | `users/omniauth_callbacks#line` | LINE Login callback を受け取り OAuth 共通認証へ渡す |
| `POST /users/auth/line/callback` | `users/omniauth_callbacks#line` | LINE Login callback を受け取り OAuth 共通認証へ渡す |

UI の比較
----

| 現状 | figma |
|:------:|:------:|
| ログイン/登録画面に LINE ボタン、外部アカウント利用時のメールアドレス取得目的、利用規約/プライバシーポリシーリンク、同意チェックを追加 | なし |

実装の詳細
----

- `omniauth-line-v2` を追加し、provider 名を `line` に統一しました
- `Oauth::ProviderConfig` を Google/LINE 両対応に拡張しました
  - credentials 優先、ENV fallback
  - `LINE_CLIENT_ID` / `LINE_CLIENT_SECRET` または `line_oauth.client_id` / `line_oauth.client_secret`
  - client id と client secret が両方ある場合のみ LINE を有効化
- Devise initializer に LINE provider を有効時のみ登録しました
  - scope: `profile openid email`
- `Users::OmniauthCallbacksController` に `line` callback action を追加しました
- `Oauth::AuthHashReader` で LINE の `extra.id_info` を読み、LINE verify API 済み ID token response の email と取得 email が一致する場合に verified email として扱うようにしました
- token / refresh token / raw_info は `UserIdentity` に保存しない既存方針を維持しています
- ログイン/登録画面の OAuth ボタンを Google/LINE 両対応にし、同意チェック後に外部アカウントボタンが有効になる Stimulus controller を追加しました
- Docker Compose で OAuth 用 ENV を web コンテナへ渡せるようにしました
- README に LINE Developers Console 設定、callback URL、scope、Email address permission、ローカル確認手順を追記しました
- RSpec で ProviderConfig、AuthHashReader、callback、ログイン/登録画面、Devise provider 登録の回帰を追加しました

追加した Gem
---

- [omniauth-line-v2](https://rubygems.org/gems/omniauth-line-v2)

備考
---

実行した確認:

```bash
docker-compose exec web bundle exec rspec
docker-compose exec web bundle exec rubocop
docker-compose exec web bundle exec erblint --lint-all
```

結果:

- RSpec: `273 examples, 0 failures, 5 pending`
- RuboCop: no offenses
- ERB Lint: no errors

ローカル確認:

- `http://localhost:3000/users/sign_in` で LINE ボタン表示を確認
- 同意チェック前は外部アカウントボタンが disabled であることを確認
- 同意チェック後に `/users/auth/line` へ POST でき、LINE 認可画面 `https://access.line.me/oauth2/v2.1/authorize` へ redirect されることを確認
<img width="637" height="669" alt="スクリーンショット 2026-06-14 10 54 57" src="https://github.com/user-attachments/assets/a8637506-36f5-4b04-a588-7304ae47a619" />
