### PR TITLE
[add] ダッシュボードのスコア表示と受験履歴をリニューアルする

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -10,6 +10,7 @@ class DashboardController < ApplicationController
     @history_page = requested_page.clamp(1, @total_history_pages)
     @latest_examination = examinations_scope.first
     @latest_score = @latest_examination&.score
+    @score_trend_data = score_trend_data(examinations_scope)
     @examinations = examinations_scope
                     .offset((@history_page - 1) * EXAMINATIONS_PER_PAGE)
                     .limit(EXAMINATIONS_PER_PAGE)
@@ -30,5 +31,38 @@ class DashboardController < ApplicationController
 
   def total_history_pages
     [(@total_examinations_count.to_f / EXAMINATIONS_PER_PAGE).ceil, 1].max
+  end
+
+  def score_trend_data(examinations_scope)
+    examinations_scope.reorder(attempt_date: :asc, created_at: :asc).map do |examination|
+      score_trend_item(examination)
+    end
+  end
+
+  def score_trend_item(examination)
+    score_trend_metadata(examination).merge(
+      score_trend_scores(examination.score, examination.test.pass_mark)
+    )
+  end
+
+  def score_trend_metadata(examination)
+    {
+      label: examination.attempt_date.strftime('%Y/%m/%d'),
+      test: examination.test.decorate.implementation_year
+    }
+  end
+
+  def score_trend_scores(score, pass_mark)
+    {
+      percentage: score_percentage(score.total_score, pass_mark.total_score),
+      pass_percentage: score_percentage(pass_mark.required_score, pass_mark.total_score),
+      total_score: score.total_score,
+      required_score: pass_mark.required_score,
+      full_score: pass_mark.total_score
+    }
+  end
+
+  def score_percentage(score, full_score)
+    (score.to_f / full_score * 100).round(1)
   end
 end

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,10 +1,34 @@
 class DashboardController < ApplicationController
+  EXAMINATIONS_PER_PAGE = 10
+
   before_action :authenticate_user!
 
   def index
-    # current_userの最新のexamaminationを取得
-    @latest_examination = current_user.examinations.order(created_at: :desc).first
-    # latest_examinationのscoreを取得
-    @latest_score = @latest_examination.score if @latest_examination
+    examinations_scope = ordered_examinations
+    @total_examinations_count = examinations_scope.count
+    @total_history_pages = total_history_pages
+    @history_page = requested_page.clamp(1, @total_history_pages)
+    @latest_examination = examinations_scope.first
+    @latest_score = @latest_examination&.score
+    @examinations = examinations_scope
+                    .offset((@history_page - 1) * EXAMINATIONS_PER_PAGE)
+                    .limit(EXAMINATIONS_PER_PAGE)
+  end
+
+  private
+
+  def ordered_examinations
+    current_user
+      .examinations
+      .includes(:score, test: :pass_mark)
+      .order(attempt_date: :desc, created_at: :desc)
+  end
+
+  def requested_page
+    params[:page].to_i
+  end
+
+  def total_history_pages
+    [(@total_examinations_count.to_f / EXAMINATIONS_PER_PAGE).ceil, 1].max
   end
 end

--- a/app/javascript/controllers/dashboard_history_controller.js
+++ b/app/javascript/controllers/dashboard_history_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="dashboard-history"
+export default class extends Controller {
+  static targets = ["chart", "tab", "table"]
+
+  connect() {
+    this.currentPanel = "table"
+    this.showCurrentPanel()
+  }
+
+  switch(event) {
+    this.currentPanel = event.currentTarget.dataset.panel
+    this.showCurrentPanel()
+  }
+
+  showCurrentPanel() {
+    this.tableTarget.classList.toggle("hidden", this.currentPanel !== "table")
+    this.chartTarget.classList.toggle("hidden", this.currentPanel !== "chart")
+    this.updateTabs()
+  }
+
+  updateTabs() {
+    this.tabTargets.forEach((tab) => {
+      const selected = tab.dataset.panel === this.currentPanel
+
+      tab.classList.toggle("border-blue-700", selected)
+      tab.classList.toggle("text-blue-700", selected)
+      tab.classList.toggle("border-transparent", !selected)
+      tab.classList.toggle("text-gray-500", !selected)
+    })
+  }
+}

--- a/app/javascript/controllers/score_trend_chart_controller.js
+++ b/app/javascript/controllers/score_trend_chart_controller.js
@@ -1,0 +1,119 @@
+import { Controller } from "@hotwired/stimulus"
+import Chart from "chart.js/auto"
+
+// Connects to data-controller="score-trend-chart"
+export default class extends Controller {
+  static targets = ["canvas", "empty"]
+  static values = { scores: Array }
+
+  connect() {
+    if (this.scoresValue.length === 0) {
+      this.canvasTarget.classList.add("hidden")
+      this.emptyTarget.classList.remove("hidden")
+      return
+    }
+
+    this.drawChart()
+  }
+
+  disconnect() {
+    this.destroyChart()
+  }
+
+  drawChart() {
+    this.destroyChart()
+
+    this.chart = new Chart(this.canvasTarget, {
+      type: "line",
+      data: {
+        labels: this.scoresValue.map((score) => score.label),
+        datasets: [
+          {
+            label: "得点率",
+            data: this.scoresValue.map((score) => score.percentage),
+            borderColor: "#2563eb",
+            backgroundColor: "rgba(37, 99, 235, 0.12)",
+            pointBackgroundColor: "#2563eb",
+            pointBorderColor: "#1e40af",
+            pointRadius: 4,
+            pointHoverRadius: 6,
+            borderWidth: 2,
+            fill: true,
+            tension: 0.25,
+            customScores: this.scoresValue,
+          },
+          {
+            label: "合格基準",
+            data: this.scoresValue.map((score) => score.pass_percentage),
+            borderColor: "#059669",
+            backgroundColor: "rgba(5, 150, 105, 0.08)",
+            pointBackgroundColor: "#059669",
+            pointBorderColor: "#047857",
+            pointRadius: 4,
+            pointHoverRadius: 6,
+            borderWidth: 2,
+            borderDash: [6, 4],
+            fill: false,
+            tension: 0.25,
+            customScores: this.scoresValue,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: {
+            beginAtZero: true,
+            max: 100,
+            grid: {
+              color: "rgba(148, 163, 184, 0.25)",
+            },
+            ticks: {
+              color: "#475569",
+              callback: (value) => `${value}%`,
+            },
+          },
+          x: {
+            grid: {
+              color: "rgba(148, 163, 184, 0.18)",
+            },
+            ticks: {
+              color: "#475569",
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            display: true,
+            labels: {
+              color: "#475569",
+              usePointStyle: true,
+            },
+          },
+          tooltip: {
+            callbacks: {
+              title: (items) => this.scoresValue[items[0].dataIndex].test,
+              label: (context) => this.scoreLabel(context.dataset.label, context.dataset.customScores[context.dataIndex]),
+            },
+          },
+        },
+      },
+    })
+  }
+
+  scoreLabel(label, score) {
+    if (label === "合格基準") {
+      return `${label}: ${score.required_score}/${score.full_score}点 (${score.pass_percentage}%)`
+    }
+
+    return `${label}: ${score.total_score}/${score.full_score}点 (${score.percentage}%)`
+  }
+
+  destroyChart() {
+    if (this.chart) {
+      this.chart.destroy()
+      this.chart = null
+    }
+  }
+}

--- a/app/views/dashboard/_empty_state.html.erb
+++ b/app/views/dashboard/_empty_state.html.erb
@@ -1,0 +1,6 @@
+<div class='w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg'>
+    <div class='m-5'>
+        <h2 class='font-bold text-lg'>前回のスコア</h2>
+        <p class='mt-4 text-sm text-gray-500'>受験履歴はまだありません。</p>
+    </div>
+</div>

--- a/app/views/dashboard/_examination_history.html.erb
+++ b/app/views/dashboard/_examination_history.html.erb
@@ -1,0 +1,50 @@
+<div class='w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg' data-testid='examination-history'>
+    <div class='m-5'>
+        <h2 class='font-bold text-lg'>受験履歴</h2>
+
+        <div class='mt-4 overflow-x-auto'>
+            <table class='w-full min-w-[760px] table-auto border-collapse text-center text-sm'>
+                <thead>
+                <tr>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>受験日</th>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>試験回</th>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>共通</th>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>実地</th>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>総得点</th>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>合格基準</th>
+                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>レポート</th>
+                </tr>
+                </thead>
+                <tbody>
+                <% examinations.each do |examination| %>
+                    <tr>
+                        <td class='border border-gray-200 px-4 py-3 text-gray-600'>
+                            <%= examination.attempt_date.strftime('%Y年%m月%d日') %>
+                        </td>
+                        <td class='border border-gray-200 px-4 py-3 font-bold text-gray-700'>
+                            <%= examination.test.decorate.implementation_year %>
+                        </td>
+                        <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
+                            <%= examination.score.common_score %>
+                        </td>
+                        <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
+                            <%= examination.score.practical_score %>
+                        </td>
+                        <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
+                            <%= examination.score.total_score %>
+                        </td>
+                        <td class='border border-gray-200 px-4 py-3 font-bold text-emerald-600'>
+                            <%= examination.test.pass_mark.required_score %>
+                        </td>
+                        <td class='border border-gray-200 px-4 py-3'>
+                            <%= link_to '確認する',
+                                        examination_path(examination),
+                                        class: 'font-bold text-sky-600 hover:text-sky-800' %>
+                        </td>
+                    </tr>
+                <% end %>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>

--- a/app/views/dashboard/_examination_history.html.erb
+++ b/app/views/dashboard/_examination_history.html.erb
@@ -1,50 +1,77 @@
-<div class='w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg' data-testid='examination-history'>
+<div class='w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg'
+     data-controller='dashboard-history'
+     data-testid='examination-history'>
     <div class='m-5'>
         <h2 class='font-bold text-lg'>受験履歴</h2>
 
-        <div class='mt-4 overflow-x-auto'>
-            <table class='w-full min-w-[760px] table-auto border-collapse text-center text-sm'>
-                <thead>
-                <tr>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>受験日</th>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>試験回</th>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>共通</th>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>実地</th>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>総得点</th>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>合格基準</th>
-                    <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>レポート</th>
-                </tr>
-                </thead>
-                <tbody>
-                <% examinations.each do |examination| %>
+        <div class='mt-4 flex gap-2 border-b border-gray-200'>
+            <button type='button' class='border-b-2 px-4 py-2 text-sm font-bold'
+                    data-dashboard-history-target='tab' data-panel='table'
+                    data-action='dashboard-history#switch'>
+                履歴
+            </button>
+            <button type='button' class='border-b-2 px-4 py-2 text-sm font-bold'
+                    data-dashboard-history-target='tab' data-panel='chart'
+                    data-action='dashboard-history#switch'>
+                得点率推移
+            </button>
+        </div>
+
+        <div data-dashboard-history-target='table'>
+            <div class='mt-4 overflow-x-auto'>
+                <table class='w-full min-w-[760px] table-auto border-collapse text-center text-sm'>
+                    <thead>
                     <tr>
-                        <td class='border border-gray-200 px-4 py-3 text-gray-600'>
-                            <%= examination.attempt_date.strftime('%Y年%m月%d日') %>
-                        </td>
-                        <td class='border border-gray-200 px-4 py-3 font-bold text-gray-700'>
-                            <%= examination.test.decorate.implementation_year %>
-                        </td>
-                        <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
-                            <%= examination.score.common_score %>
-                        </td>
-                        <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
-                            <%= examination.score.practical_score %>
-                        </td>
-                        <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
-                            <%= examination.score.total_score %>
-                        </td>
-                        <td class='border border-gray-200 px-4 py-3 font-bold text-emerald-600'>
-                            <%= examination.test.pass_mark.required_score %>
-                        </td>
-                        <td class='border border-gray-200 px-4 py-3'>
-                            <%= link_to '確認する',
-                                        examination_path(examination),
-                                        class: 'font-bold text-sky-600 hover:text-sky-800' %>
-                        </td>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>受験日</th>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>試験回</th>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>共通</th>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>実地</th>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>総得点</th>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>合格基準</th>
+                        <th class='border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600'>レポート</th>
                     </tr>
-                <% end %>
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                    <% examinations.each do |examination| %>
+                        <tr>
+                            <td class='border border-gray-200 px-4 py-3 text-gray-600'>
+                                <%= examination.attempt_date.strftime('%Y年%m月%d日') %>
+                            </td>
+                            <td class='border border-gray-200 px-4 py-3 font-bold text-gray-700'>
+                                <%= examination.test.decorate.implementation_year %>
+                            </td>
+                            <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
+                                <%= examination.score.common_score %>
+                            </td>
+                            <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
+                                <%= examination.score.practical_score %>
+                            </td>
+                            <td class='border border-gray-200 px-4 py-3 font-bold text-blue-700'>
+                                <%= examination.score.total_score %>
+                            </td>
+                            <td class='border border-gray-200 px-4 py-3 font-bold text-emerald-600'>
+                                <%= examination.test.pass_mark.required_score %>
+                            </td>
+                            <td class='border border-gray-200 px-4 py-3'>
+                                <%= link_to '確認する',
+                                            examination_path(examination),
+                                            class: 'font-bold text-sky-600 hover:text-sky-800' %>
+                            </td>
+                        </tr>
+                    <% end %>
+                    </tbody>
+                </table>
+            </div>
+
+            <% if total_pages > 1 %>
+                <%= render 'pagination',
+                           current_page:,
+                           total_pages: %>
+            <% end %>
+        </div>
+
+        <div class='hidden' data-dashboard-history-target='chart'>
+            <%= render 'score_trend_chart', score_trend_data: %>
         </div>
     </div>
 </div>

--- a/app/views/dashboard/_latest_score.html.erb
+++ b/app/views/dashboard/_latest_score.html.erb
@@ -1,0 +1,7 @@
+<div class='flex mb-8'>
+    <%= render 'shared/score_report_card',
+               title: '前回のスコア',
+               examination: examination,
+               score: examination.score,
+               report_link: true %>
+</div>

--- a/app/views/dashboard/_pagination.html.erb
+++ b/app/views/dashboard/_pagination.html.erb
@@ -1,0 +1,29 @@
+<nav class='mt-5 flex items-center justify-center gap-2' aria-label='受験履歴ページネーション'>
+    <% if current_page > 1 %>
+        <%= link_to '前へ',
+                    dashboard_path(page: current_page - 1),
+                    class: 'rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-700
+                            hover:bg-blue-50' %>
+    <% end %>
+
+    <% 1.upto(total_pages) do |page| %>
+        <% if page == current_page %>
+            <span class='rounded-lg border border-blue-700 bg-blue-700 px-3 py-2 text-sm font-bold text-white'
+                  aria-current='page'>
+                <%= page %>
+            </span>
+        <% else %>
+            <%= link_to page,
+                        dashboard_path(page:),
+                        class: 'rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-700
+                                hover:bg-blue-50' %>
+        <% end %>
+    <% end %>
+
+    <% if current_page < total_pages %>
+        <%= link_to '次へ',
+                    dashboard_path(page: current_page + 1),
+                    class: 'rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-700
+                            hover:bg-blue-50' %>
+    <% end %>
+</nav>

--- a/app/views/dashboard/_score_trend_chart.html.erb
+++ b/app/views/dashboard/_score_trend_chart.html.erb
@@ -1,0 +1,10 @@
+<div class='mt-4'
+     data-controller='score-trend-chart'
+     data-score-trend-chart-scores-value='<%= json_escape(score_trend_data.to_json) %>'>
+    <div class='h-80'>
+        <canvas data-score-trend-chart-target='canvas'></canvas>
+        <p class='hidden py-10 text-center text-gray-500' data-score-trend-chart-target='empty'>
+            得点率の推移を表示できる受験履歴がありません。
+        </p>
+    </div>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -3,12 +3,11 @@
         <div class='mb-10 mt-5'>
             <% if @latest_examination.present? %>
                 <%= render 'latest_score', examination: @latest_examination %>
-                <%= render 'examination_history', examinations: @examinations %>
-                <% if @total_history_pages > 1 %>
-                    <%= render 'pagination',
-                               current_page: @history_page,
-                               total_pages: @total_history_pages %>
-                <% end %>
+                <%= render 'examination_history',
+                           examinations: @examinations,
+                           score_trend_data: @score_trend_data,
+                           current_page: @history_page,
+                           total_pages: @total_history_pages %>
             <% else %>
                 <%= render 'empty_state' %>
             <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,57 +1,17 @@
 <div class='flex flex-wrap body-font'>
-    <div class='w-full max-w-4xl m-auto'>
-        <!-- 前回のレポートセクション -->
-        <div class='flex mb-10'>
-            <div class='w-full h-full border-2 border-gray-200 border-opacity-60 rounded-lg overflow-hidden shadow-xl'>
-                <div class='m-5'>
-                    <h2 class='font-bold text-xl'>前回のスコア</h2>
-                    <div class='text-center my-2 text-4xl text-sky-500'>
-                        <% if @latest_examination&.test %>
-                            <%= @latest_examination.test.decorate.implementation_year %>
-                        <% else %>
-                            -
-                        <% end %>
-                    </div>
-                    <div class='flex justify-center py-2'>
-                        <div class='flex flex-col text-center border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500 mx-8'>共通</h3>
-                            <div class='text-3xl text-sky-500'><%= @latest_score&.common_score || '-' %></div>
-                        </div>
-                        <div class='flex flex-col text-center border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500 mx-8'>実地</h3>
-                            <div class='text-3xl text-sky-500'><%= @latest_score&.practical_score || '-' %></div>
-                        </div>
-                        <div class='flex flex-col text-center border-r-4 border-gray-200'>
-                            <h3 class='text-3xl text-gray-500 mx-8'>総得点</h3>
-                            <div class='text-3xl text-sky-500'><%= @latest_score&.total_score || '-' %></div>
-                        </div>
-                        <div class='flex flex-col text-center'>
-                            <h3 class='text-3xl text-gray-500 mx-8'>合格点</h3>
-                            <div class='text-3xl text-sky-500'>
-                                <% if @latest_examination&.test&.pass_mark %>
-                                    <%= @latest_examination.test.pass_mark.total_score %>
-                                <% else %>
-                                    -
-                                <% end %>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="text-center m-2">
-                    <% if @latest_examination.present? %>
-                        <%= link_to examination_path(@latest_examination),
-                                    class: 'inline-flex items-center bg-sky-100 text-gray-700
-                                            hover:bg-sky-500 hover:text-orange-300 font-bold
-                                            py-2 px-4 rounded-lg shadow-xl' do %>
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6 mr-2">
-                                <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607ZM10.5 7.5v6m3-3h-6" />
-                            </svg>
-                            レポートを確認する
-                        <% end %>
-                    <% end %>
-                </div>
-            </div>
+    <div class='w-full max-w-5xl m-auto px-4'>
+        <div class='mb-10 mt-5'>
+            <% if @latest_examination.present? %>
+                <%= render 'latest_score', examination: @latest_examination %>
+                <%= render 'examination_history', examinations: @examinations %>
+                <% if @total_history_pages > 1 %>
+                    <%= render 'pagination',
+                               current_page: @history_page,
+                               total_pages: @total_history_pages %>
+                <% end %>
+            <% else %>
+                <%= render 'empty_state' %>
+            <% end %>
         </div>
 
         <!-- 学習進捗セクション -->

--- a/app/views/examinations/show.html.erb
+++ b/app/views/examinations/show.html.erb
@@ -17,63 +17,10 @@
             <div data-results-display-target='report'>
                 <!-- レポートセクション -->
                 <div class='flex mb-8'>
-                    <div class='w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg'>
-                        <div class='m-5'>
-                            <div class='flex flex-wrap items-center gap-x-3 gap-y-1'>
-                                <h2 class='font-bold text-lg'>レポート</h2>
-                                <h3 class='text-sm text-gray-500'>
-                                    受験日：<%= @examination.attempt_date.strftime('%Y年%m月%d日') %>
-                                </h3>
-                            </div>
-                            <div class='flex justify-center items-baseline'>
-                                <div class='my-3 text-2xl font-bold text-blue-700'>
-                                    <%= @examination.test.decorate.implementation_year %>
-                                </div>
-                                <p class='text-sm text-gray-500 ml-2'><%= @examination.test.pass_mark.total_score %>点満点</p>
-                            </div>
-
-                            <!-- テーブル表示 -->
-                            <table class="table-auto w-full text-center border-collapse text-sm">
-                                <thead>
-                                <tr>
-                                    <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600"></th>
-                                    <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600">共通</th>
-                                    <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600">実地</th>
-                                    <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600">総得点</th>
-                                </tr>
-                                </thead>
-                                <tbody>
-                                <!-- ユーザーの得点 -->
-                                <tr>
-                                    <td class="border border-gray-200 px-4 py-3 font-bold text-gray-600">
-                                        <%= @examination.user.username %>の得点
-                                    </td>
-                                    <td class="border border-gray-200 px-4 py-3 text-xl font-bold text-blue-700">
-                                        <%= @score.common_score %>
-                                    </td>
-                                    <td class="border border-gray-200 px-4 py-3 text-xl font-bold text-blue-700">
-                                        <%= @score.practical_score %>
-                                    </td>
-                                    <td class="border border-gray-200 px-4 py-3 text-xl font-bold text-blue-700">
-                                        <%= @score.total_score %>
-                                    </td>
-                                </tr>
-
-                                <!-- 合格基準 -->
-                                <tr>
-                                    <td class="border border-gray-200 px-4 py-3 font-bold text-gray-600">合格基準</td>
-                                    <td class="border border-gray-200 px-4 py-3 text-lg font-bold text-emerald-600"><%# 共通の合格点は設定されていない %></td>
-                                    <td class="border border-gray-200 px-4 py-3 text-lg font-bold text-emerald-600">
-                                        <%= @examination.test.pass_mark.required_practical_score %>
-                                    </td>
-                                    <td class="border border-gray-200 px-4 py-3 text-lg font-bold text-emerald-600">
-                                        <%= @examination.test.pass_mark.required_score %>
-                                    </td>
-                                </tr>
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                    <%= render 'shared/score_report_card',
+                               title: 'レポート',
+                               examination: @examination,
+                               score: @score %>
                 </div>
 
                 <!-- 正答率 -->

--- a/app/views/shared/_score_report_card.html.erb
+++ b/app/views/shared/_score_report_card.html.erb
@@ -1,0 +1,64 @@
+<div class='w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg'>
+    <div class='m-5'>
+        <div class='flex flex-wrap items-center gap-x-3 gap-y-1'>
+            <h2 class='font-bold text-lg'><%= title %></h2>
+            <h3 class='text-sm text-gray-500'>
+                受験日：<%= examination.attempt_date.strftime('%Y年%m月%d日') %>
+            </h3>
+        </div>
+        <div class='flex justify-center items-baseline'>
+            <div class='my-3 text-2xl font-bold text-blue-700'>
+                <%= examination.test.decorate.implementation_year %>
+            </div>
+            <p class='text-sm text-gray-500 ml-2'><%= examination.test.pass_mark.total_score %>点満点</p>
+        </div>
+
+        <table class="table-auto w-full text-center border-collapse text-sm">
+            <thead>
+            <tr>
+                <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600"></th>
+                <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600">共通</th>
+                <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600">実地</th>
+                <th class="border border-blue-100 bg-blue-50 px-4 py-3 text-gray-600">総得点</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="border border-gray-200 px-4 py-3 font-bold text-gray-600">
+                    <%= examination.user.username %>の得点
+                </td>
+                <td class="border border-gray-200 px-4 py-3 text-xl font-bold text-blue-700">
+                    <%= score.common_score %>
+                </td>
+                <td class="border border-gray-200 px-4 py-3 text-xl font-bold text-blue-700">
+                    <%= score.practical_score %>
+                </td>
+                <td class="border border-gray-200 px-4 py-3 text-xl font-bold text-blue-700">
+                    <%= score.total_score %>
+                </td>
+            </tr>
+
+            <tr>
+                <td class="border border-gray-200 px-4 py-3 font-bold text-gray-600">合格基準</td>
+                <td class="border border-gray-200 px-4 py-3 text-lg font-bold text-emerald-600"><%# 共通の合格点は設定されていない %></td>
+                <td class="border border-gray-200 px-4 py-3 text-lg font-bold text-emerald-600">
+                    <%= examination.test.pass_mark.required_practical_score %>
+                </td>
+                <td class="border border-gray-200 px-4 py-3 text-lg font-bold text-emerald-600">
+                    <%= examination.test.pass_mark.required_score %>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <% if local_assigns.fetch(:report_link, false) %>
+            <div class='mt-5 text-center'>
+                <%= link_to examination_path(examination),
+                            class: 'inline-flex items-center rounded-lg bg-sky-100 px-4 py-2 font-bold text-gray-700
+                                    shadow-xl hover:bg-sky-500 hover:text-orange-300' do %>
+                    レポートを確認する
+                <% end %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -70,6 +70,21 @@ RSpec.describe 'Dashboards' do
           expect(rows[1]).to have_text('第58回(2023年度)')
           expect(rows[1]).to have_link('確認する', href: examination_path(old_examination))
         end
+
+        it '受験履歴カードに得点率推移グラフのタブを表示する' do
+          get '/dashboard'
+
+          html = Capybara.string(response.body)
+          history = html.find("[data-testid='examination-history']")
+
+          expect(history).to have_button('履歴')
+          expect(history).to have_button('得点率推移')
+          expect(history).to have_css("[data-controller='score-trend-chart']")
+          expect(response.body).to include('&quot;percentage&quot;:70.0')
+          expect(response.body).to include('&quot;percentage&quot;:75.0')
+          expect(response.body).to include('&quot;pass_percentage&quot;:75.0')
+          expect(response.body).to include('&quot;pass_percentage&quot;:80.0')
+        end
       end
 
       context '受験履歴がない場合' do

--- a/spec/requests/dashboard_spec.rb
+++ b/spec/requests/dashboard_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Dashboards' do
   describe 'GET /index' do
     let(:user) { create(:user) }
-    let(:test) { create(:test) }
-    let!(:pass_mark) { create(:pass_mark, test:) }
-    let!(:examination) { create(:examination, test:, user:) }
-    let!(:score) { create(:score, examination:) }
 
     context '認証済みユーザーの場合' do
       before do
@@ -16,6 +12,117 @@ RSpec.describe 'Dashboards' do
       it 'returns http success' do
         get '/dashboard'
         expect(response).to have_http_status(:success)
+      end
+
+      context '受験履歴がある場合' do
+        let(:latest_test) { create(:test, year: '2024') }
+        let(:old_test) { create(:test, year: '2023') }
+        let!(:latest_pass_mark) do
+          create(:pass_mark, test: latest_test, total_score: 200, required_practical_score: 40, required_score: 160)
+        end
+        let!(:old_pass_mark) do
+          create(:pass_mark, test: old_test, total_score: 200, required_practical_score: 35, required_score: 150)
+        end
+        let!(:latest_examination) do
+          create(:examination, test: latest_test, user:, attempt_date: Time.zone.local(2024, 6, 2, 10, 0, 0))
+        end
+        let!(:old_examination) do
+          create(:examination, test: old_test, user:, attempt_date: Time.zone.local(2023, 5, 1, 10, 0, 0))
+        end
+        let!(:latest_score) do
+          create(:score, examination: latest_examination, common_score: 80, practical_score: 70, total_score: 150)
+        end
+        let!(:old_score) do
+          create(:score, examination: old_examination, common_score: 75, practical_score: 65, total_score: 140)
+        end
+
+        it '最新の受験結果を前回のスコアとして表示する' do
+          get '/dashboard'
+
+          expect(response.body).to include('前回のスコア')
+          expect(response.body).to include('受験日：2024年06月02日')
+          expect(response.body).to include('第59回(2024年度)')
+          expect(response.body).to include('80')
+          expect(response.body).to include('70')
+          expect(response.body).to include('150')
+          expect(response.body).to include('40')
+          expect(response.body).to include('160')
+          expect(Capybara.string(response.body)).to have_link('レポートを確認する',
+                                                              href: examination_path(latest_examination))
+        end
+
+        it '受験履歴を新しい順で表示し、各レポートへのリンクを表示する' do
+          get '/dashboard'
+
+          html = Capybara.string(response.body)
+          history = html.find("[data-testid='examination-history']")
+          rows = history.all('tbody tr')
+
+          expect(rows.size).to eq(2)
+          expect(rows[0]).to have_text('2024年06月02日')
+          expect(rows[0]).to have_text('第59回(2024年度)')
+          expect(rows[0]).to have_text('80')
+          expect(rows[0]).to have_text('70')
+          expect(rows[0]).to have_text('150')
+          expect(rows[0]).to have_text('160')
+          expect(rows[0]).to have_link('確認する', href: examination_path(latest_examination))
+          expect(rows[1]).to have_text('2023年05月01日')
+          expect(rows[1]).to have_text('第58回(2023年度)')
+          expect(rows[1]).to have_link('確認する', href: examination_path(old_examination))
+        end
+      end
+
+      context '受験履歴がない場合' do
+        it '空状態メッセージを表示する' do
+          get '/dashboard'
+
+          expect(response).to have_http_status(:success)
+          expect(response.body).to include('受験履歴はまだありません。')
+          expect(response.body).not_to include('data-testid=\'examination-history\'')
+        end
+      end
+
+      context '受験履歴が11件ある場合' do
+        let(:test) { create(:test, year: '2024') }
+        let!(:pass_mark) { create(:pass_mark, test:) }
+        let!(:examinations) do
+          Array.new(11) do |index|
+            examination = create(:examination,
+                                 test:,
+                                 user:,
+                                 attempt_date: Time.zone.local(2024, 1, index + 1, 10, 0, 0))
+            create(:score,
+                   examination:,
+                   common_score: index + 1,
+                   practical_score: index + 2,
+                   total_score: index + 3)
+            examination
+          end
+        end
+
+        it '受験履歴を10件ごとにページングする' do
+          get '/dashboard'
+
+          html = Capybara.string(response.body)
+          history = html.find("[data-testid='examination-history']")
+          rows = history.all('tbody tr')
+
+          expect(rows.size).to eq(10)
+          expect(rows[0]).to have_text('2024年01月11日')
+          expect(rows[9]).to have_text('2024年01月02日')
+          expect(history).not_to have_text('2024年01月01日')
+          expect(html).to have_link('次へ', href: dashboard_path(page: 2))
+
+          get '/dashboard', params: { page: 2 }
+
+          html = Capybara.string(response.body)
+          history = html.find("[data-testid='examination-history']")
+          rows = history.all('tbody tr')
+
+          expect(rows.size).to eq(1)
+          expect(rows[0]).to have_text('2024年01月01日')
+          expect(html).to have_link('前へ', href: dashboard_path(page: 1))
+        end
       end
     end
 


### PR DESCRIPTION
対応するissue
---
Closes #195

概要
---

`/dashboard` の前回スコア表示を `/examinations/:id` のレポートカードと共通化し、受験履歴テーブルと得点率推移グラフを追加しました。

エンドポイント
---

| エンドポイント | コントローラ#アクション | 役割 |
| --- | ---  | --- |
| `GET /dashboard` | `dashboard#index` | ダッシュボードで前回スコア、受験履歴、得点率推移を表示する |
| `GET /examinations/:id` | `examinations#show` | 共通化したスコアレポートカードで受験レポートを表示する |

UI の比較
----

| 現状 | figma |
|:------:|:------:|
| なし | なし |

実装の詳細
----

- `/examinations/:id` のスコアレポートカードを `shared/score_report_card` に切り出し、ダッシュボードの前回スコア表示でも利用するようにしました。
- ダッシュボードに受験履歴テーブルを追加し、各行から該当の受験レポートへ遷移できるようにしました。
- 受験履歴テーブルは `attempt_date` の新しい順で表示し、10件ごとにページングします。
- 受験履歴カードに「履歴」「得点率推移」のタブを追加しました。
- 得点率推移グラフでは、過去の受験履歴を古い順に並べて折れ線グラフで表示します。
- ダッシュボード表示時の N+1 を避けるため、`score` と `test.pass_mark` を eager load しています。

後で確認したくなりそうな項目
----

- 得点率の計算式は `総得点 / 満点 * 100` で、小数第1位まで丸めています。
- 合格基準線の計算式は `合格点 / 満点 * 100` で、小数第1位まで丸めています。
- グラフの青い実線はユーザーの得点率、緑の破線は合格基準です。
- 最新スコアカードはページングの影響を受けず、常に全受験履歴の最新1件を表示します。
- 受験履歴テーブルはページング対象ですが、得点率推移グラフは全受験履歴を対象にしています。
- 受験履歴がないユーザーには空状態メッセージを表示します。

追加した Gem
---

- なし

備考
---

実行した確認コマンド:

- `docker-compose exec web bundle exec rspec spec/requests/dashboard_spec.rb spec/requests/examinations_spec.rb`
- `docker-compose exec web bundle exec rubocop app/controllers/dashboard_controller.rb spec/requests/dashboard_spec.rb`
- `docker-compose exec web bundle exec erb_lint app/views/dashboard/index.html.erb app/views/dashboard/_examination_history.html.erb app/views/dashboard/_pagination.html.erb app/views/dashboard/_score_trend_chart.html.erb`

RSpec 実行時に既存の `fixture_path` deprecation warning が表示されますが、今回の変更起因ではありません。
